### PR TITLE
Fix character token text color and shape

### DIFF
--- a/script.js
+++ b/script.js
@@ -1301,7 +1301,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const path = document.createElementNS('http://www.w3.org/2000/svg','path');
       path.setAttribute('id', uniqueId);
       // Perfect bottom half-circle inside the token rim
-      path.setAttribute('d','M10,50 A40,40 0 0,1 90,50');
+      path.setAttribute('d','M10,50 A40,40 0 0,0 90,50');
       defs.appendChild(path);
       svg.appendChild(defs);
           const text = document.createElementNS('http://www.w3.org/2000/svg','text');

--- a/script.js
+++ b/script.js
@@ -1300,8 +1300,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const defs = document.createElementNS('http://www.w3.org/2000/svg','defs');
       const path = document.createElementNS('http://www.w3.org/2000/svg','path');
       path.setAttribute('id', uniqueId);
-      // Widen and raise arc so full string fits and stays inside the rim
-      path.setAttribute('d','M16,72 A34,34 0 0,0 84,72');
+      // Perfect bottom half-circle inside the token rim
+      path.setAttribute('d','M10,50 A40,40 0 0,1 90,50');
       defs.appendChild(path);
       svg.appendChild(defs);
           const text = document.createElementNS('http://www.w3.org/2000/svg','text');

--- a/styles.css
+++ b/styles.css
@@ -388,7 +388,7 @@ body {
 
 /* Character modal specific text styling */
 #character-grid .icon-reminder-text {
-  fill: #D4AF37;
+  fill: #ffffff;
   stroke: rgba(0,0,0,0.9);
   stroke-width: 2.5px;
   font-size: 12px;


### PR DESCRIPTION
Update character selection popup text color to white and adjust token text arc to a true half-circle.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee373cf7-9ab7-4fc1-a199-1f097355d392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee373cf7-9ab7-4fc1-a199-1f097355d392">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

