### PR TITLE
Prevent initial new version prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,6 +4,15 @@ if ('serviceWorker' in navigator) {
       .then(registration => {
         console.log('Service worker registered successfully:', registration);
         
+        // Suppress update prompt only on first standalone launch (A2HS first open)
+        const isStandalone = (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) || (window.navigator.standalone === true);
+        const FIRST_LAUNCH_KEY = 'pwa_first_standalone_launch_done';
+        let suppressUpdatePrompt = false;
+        if (isStandalone && !localStorage.getItem(FIRST_LAUNCH_KEY)) {
+          suppressUpdatePrompt = true;
+          localStorage.setItem(FIRST_LAUNCH_KEY, '1');
+        }
+        
         // Check for updates on page load
         registration.update();
         
@@ -18,11 +27,19 @@ if ('serviceWorker' in navigator) {
           console.log('Service worker update found!');
           
           newWorker.addEventListener('statechange', () => {
-            if (newWorker.state === 'activated' && navigator.serviceWorker.controller) {
-              console.log('New service worker activated');
-              // Optionally notify user about the update
-              if (confirm('A new version is available! Reload to update?')) {
-                window.location.reload();
+            if (newWorker.state === 'installed') {
+              // Only prompt if there's an existing controller (i.e., this is an update, not first install)
+              if (navigator.serviceWorker.controller) {
+                console.log('New service worker installed (update available)');
+                if (!suppressUpdatePrompt) {
+                  if (confirm('A new version is available! Reload to update?')) {
+                    window.location.reload();
+                  }
+                } else {
+                  console.log('Suppressing update prompt on first standalone launch');
+                }
+              } else {
+                console.log('Service worker installed for the first time');
               }
             }
           });


### PR DESCRIPTION
Suppress the "new version" prompt on the first PWA launch from the home screen to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-3148dc00-6d37-41dc-80ea-ac3c3c369a22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3148dc00-6d37-41dc-80ea-ac3c3c369a22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

