### PR TITLE
Persist cache name updates with releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,6 +36,18 @@ jobs:
           
           # Show the change
           grep "const CACHE_NAME" service-worker.js
+
+      - name: Commit cache version bump
+        run: |
+          if git diff --quiet service-worker.js; then
+            echo "No cache version change to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add service-worker.js
+            git commit -m "chore: bump service worker cache [skip ci]"
+            git push
+          fi
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
Persist `CACHE_NAME` updates in `service-worker.js` by committing changes back to the repository during deployment.

The previous setup updated `CACHE_NAME` only in the deployed artifact, leading to a mismatch between the repository and the deployed version. This change ensures the `CACHE_NAME` in `service-worker.js` is always in sync with the version used in the release, improving cache busting reliability. A `[skip ci]` guard is added to prevent workflow re-triggers.

---
<a href="https://cursor.com/background-agent?bcId=bc-c73bceba-1db3-4b5c-a039-4927dc84735d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c73bceba-1db3-4b5c-a039-4927dc84735d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

