### PR TITLE
Autosave current game to history

### DIFF
--- a/tests/02_game.cy.js
+++ b/tests/02_game.cy.js
@@ -158,8 +158,8 @@ describe('Game', () => {
     // There should be at least one grimoire history entry
     cy.get('#grimoire-history-list .history-item').should('have.length.greaterThan', 0);
 
-    // Rename first
-    cy.get('#grimoire-history-list .history-item').first().within(() => {
+    // Rename first non-current item (index 1, since index 0 is the pinned current game)
+    cy.get('#grimoire-history-list .history-item').eq(1).within(() => {
       cy.get('.icon-btn.rename').click();
       cy.get('.history-edit-input').clear().type('Day 1');
       cy.get('.icon-btn.save').click();


### PR DESCRIPTION
Add a pinned 'current game' entry to grimoire history that autosaves and is always shown first.

This ensures the active game state is always readily available at the top of the history list, providing a consistent and easily accessible point to return to the current session, while preventing accidental deletion or renaming of this critical entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-84e2dbbe-76bf-48f0-ad18-280a900a8a3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84e2dbbe-76bf-48f0-ad18-280a900a8a3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

