### PR TITLE
Fix reminder token text display and deletion

### DIFF
--- a/script.js
+++ b/script.js
@@ -585,11 +585,9 @@ document.addEventListener('DOMContentLoaded', () => {
       hideReminderContextMenu();
       if (playerIndex < 0 || reminderIndex < 0) return;
       if (!players[playerIndex] || !players[playerIndex].reminders) return;
-      if (confirm('Delete this reminder?')) {
-        players[playerIndex].reminders.splice(reminderIndex, 1);
-        updateGrimoire();
-        saveAppState();
-      }
+      players[playerIndex].reminders.splice(reminderIndex, 1);
+      updateGrimoire();
+      saveAppState();
     });
 
     menu.appendChild(editBtn);
@@ -1662,11 +1660,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         return;
                       }
                     }
-                    if (confirm('Delete this reminder token?')) {
-                      players[i].reminders.splice(idx, 1);
-                      updateGrimoire();
-                      saveAppState();
-                    }
+                    players[i].reminders.splice(idx, 1);
+                    updateGrimoire();
+                    saveAppState();
                   });
                   iconEl.appendChild(delBtn);
                 }
@@ -1790,11 +1786,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         return;
                       }
                     }
-                    if (confirm('Delete this reminder?')) {
-                      players[i].reminders.splice(idx, 1);
-                      updateGrimoire();
-                      saveAppState();
-                    }
+                    players[i].reminders.splice(idx, 1);
+                    updateGrimoire();
+                    saveAppState();
                   });
                   reminderEl.appendChild(delBtn2);
                 }
@@ -2232,11 +2226,14 @@ document.addEventListener('DOMContentLoaded', () => {
       if (len > 12 && len <= 16) fontSize = 11.5;
       else if (len > 16) fontSize = 11;
       text.style.fontSize = `${fontSize}px`;
-      text.style.letterSpacing = '0.1px';
-      text.setAttribute('lengthAdjust','spacingAndGlyphs');
-      // Force the displayed text to fit exactly along the arc
-      const targetLength = 92; // tweakable to the visual arc length
-      textPath.setAttribute('textLength', String(targetLength));
+      // For short labels, do NOT stretch spacing (prevents "h     i" look)
+      // Only force-fit very long labels to avoid overflow
+      if (len >= 10) {
+        text.style.letterSpacing = '0.1px';
+        text.setAttribute('lengthAdjust','spacingAndGlyphs');
+        const targetLength = 92; // visual arc length
+        textPath.setAttribute('textLength', String(targetLength));
+      }
       textPath.textContent = display;
       text.appendChild(textPath);
       svg.appendChild(text);

--- a/tests/02_game.cy.js
+++ b/tests/02_game.cy.js
@@ -101,10 +101,13 @@ describe('Game', () => {
     cy.get('#player-circle li').eq(0).trigger('mouseenter');
     cy.get('#player-circle li').eq(0).should('have.attr', 'data-expanded', '1');
 
-    // Delete one reminder via hover delete icon
+    // Delete one reminder via hover delete icon (no confirmation expected)
     cy.get('#player-circle li').eq(0).find('.reminders .icon-reminder, .reminders .text-reminder').first().trigger('mouseenter');
-    cy.window().then((win) => { cy.stub(win, 'confirm').returns(true); });
-    cy.get('#player-circle li').eq(0).find('.reminders .reminder-action.delete').first().click({ force: true });
+    cy.window().then((win) => { cy.stub(win, 'confirm').as('confirmStubGame'); });
+    cy.get('@confirmStubGame').its('callCount').then((before) => {
+      cy.get('#player-circle li').eq(0).find('.reminders .reminder-action.delete').first().click({ force: true });
+      cy.get('@confirmStubGame').its('callCount').should('eq', before);
+    });
 
     // Collapse stack
     cy.get('#player-circle li').eq(0).trigger('mouseleave');


### PR DESCRIPTION
Remove confirmation prompts for reminder token deletion and fix text spacing for short reminder labels.

The text rendering for short reminder labels (e.g., "hi") was adjusted to prevent excessive letter spacing, ensuring they appear compactly at the bottom center of the token, consistent with character tokens. This was achieved by conditionally applying `textLength` only for longer labels.

---
<a href="https://cursor.com/background-agent?bcId=bc-b81b2ffc-f622-426a-b544-bf158692d67e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b81b2ffc-f622-426a-b544-bf158692d67e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

