### PR TITLE
Add placeholder text for empty state

### DIFF
--- a/script.js
+++ b/script.js
@@ -971,7 +971,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const meta = scriptData.find(x => x && typeof x === 'object' && x.id === '_meta');
       if (meta && meta.name) scriptName = String(meta.name);
     }
-    if (!row && !scriptName) { setupInfoEl.textContent = ''; return; }
+    if (!row && !scriptName) { setupInfoEl.textContent = 'Select a script and add players from the sidebar.'; return; }
     const parts = [];
     if (scriptName) parts.push(scriptName);
     if (row) parts.push(`${row.townsfolk}/${row.outsiders}/${row.minions}/${row.demons}`);

--- a/tests/01_scripts.cy.js
+++ b/tests/01_scripts.cy.js
@@ -8,6 +8,10 @@ describe('Scripts', () => {
     });
   });
 
+  it('shows an empty-state hint before a script is loaded and before players are added', () => {
+    cy.contains('#setup-info', 'Select a script and add players from the sidebar.').should('exist');
+  });
+
   it('loads a built-in script and shows abilities that can be expanded', () => {
     cy.get('#load-tb').click();
     cy.get('#character-sheet .role').should('have.length.greaterThan', 5);


### PR DESCRIPTION
Add empty-state text to the central display area to guide users when no script is loaded and no players are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-28c2b597-9a4e-4edf-b112-05626e150aae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28c2b597-9a4e-4edf-b112-05626e150aae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

