### PR TITLE
Add jinxes to script list with descriptions

### DIFF
--- a/src/character.js
+++ b/src/character.js
@@ -56,7 +56,7 @@ export function applyTravellerToggleAndRefresh({ grimoireState }) {
     grimoireState.allRoles = { ...grimoireState.allRoles, ...(grimoireState.extraTravellerRoles || {}) };
   }
   // Re-render character sheet and, if modal is open, the character grid
-  if (Array.isArray(grimoireState.scriptData)) displayScript({ data: grimoireState.scriptData, grimoireState });
+  if (Array.isArray(grimoireState.scriptData)) displayScript({ data: grimoireState.scriptData, grimoireState }).catch(console.error);
   if (characterModal && characterModal.style.display === 'flex') {
     populateCharacterGrid({ grimoireState });
   }

--- a/src/history/script.js
+++ b/src/history/script.js
@@ -55,7 +55,7 @@ export async function handleScriptHistoryClick({ e, scriptHistoryList, grimoireS
   try {
     await processScriptData({ data: entry.data, addToHistory: false, grimoireState });
     grimoireState.scriptMetaName = entry.name || grimoireState.scriptMetaName || '';
-    displayScript({ data: grimoireState.scriptData, grimoireState });
+    await displayScript({ data: grimoireState.scriptData, grimoireState });
     saveAppState({ grimoireState });
     renderSetupInfo({ grimoireState });
   } catch (err) { console.error(err); }

--- a/src/script.js
+++ b/src/script.js
@@ -56,10 +56,12 @@ export async function displayScript({ data, grimoireState }) {
           characterSheet.appendChild(roleEl);
         });
       }
+      
+      // Display jinxes section specifically after demon team
+      if (team === 'demon') {
+        displayJinxes({ jinxData, grimoireState, characterSheet });
+      }
     });
-    
-    // Display jinxes section after all teams
-    displayJinxes({ jinxData, grimoireState, characterSheet });
   } else {
     // Fallback: show all characters in a single list
     const header = document.createElement('h3');

--- a/styles/character-sheet.css
+++ b/styles/character-sheet.css
@@ -165,3 +165,67 @@
 .team-fabled {
   color: #FFC107;
 }
+
+/* Jinx section styling */
+#character-sheet h3.team-jinxes {
+  background: rgba(255, 69, 0, 0.2);
+  color: #ff8c69;
+  border-left: 4px solid #ff4500;
+}
+
+/* Jinx entry styling */
+.jinx-entry {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  margin: 4px 0;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.jinx-entry:hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.jinx-characters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.jinx-characters .icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(212, 175, 55, 0.4);
+  flex-shrink: 0;
+}
+
+.jinx-characters .name {
+  font-size: clamp(13px, 1.6vmin, 16px);
+  color: #e0e0e0;
+}
+
+.jinx-plus {
+  color: #ff8c69;
+  font-size: 18px;
+  font-weight: bold;
+  padding: 0 4px;
+}
+
+.jinx-reason {
+  font-size: clamp(11px, 1.5vmin, 13px);
+  color: #bbb;
+  margin-top: 8px;
+  margin-left: 10px;
+  line-height: 1.4;
+  display: none;
+  width: calc(100% - 10px);
+}
+
+.jinx-entry.show-jinx-reason .jinx-reason {
+  display: block;
+}

--- a/tests/19_jinx_display.cy.js
+++ b/tests/19_jinx_display.cy.js
@@ -1,0 +1,111 @@
+// Cypress E2E tests - Jinx Display
+
+describe('Jinx Display', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      try { win.localStorage.clear(); } catch (_) {}
+    });
+  });
+
+  it('displays jinxes at the bottom of the script list after demons', () => {
+    // Load all characters which has jinxes
+    cy.get('#load-all-chars').click();
+    
+    // Wait for character sheet to be populated
+    cy.get('#character-sheet .role').should('have.length.greaterThan', 5);
+    
+    // Check that jinxes section exists at the bottom after demons
+    cy.get('#character-sheet h3.team-demon').should('exist');
+    cy.get('#character-sheet h3.team-jinxes').should('exist');
+    
+    // Jinxes section should be after demons
+    cy.get('#character-sheet h3').then(($headers) => {
+      const headers = $headers.toArray().map(el => el.textContent);
+      const demonIndex = headers.indexOf('Demon');
+      const jinxIndex = headers.indexOf('Jinxes');
+      expect(jinxIndex).to.be.greaterThan(demonIndex);
+    });
+  });
+
+  it('shows jinxed character pairs in the jinxes section', () => {
+    // Load all characters which definitely has characters with jinxes
+    cy.get('#load-all-chars').click();
+    
+    // Wait for character sheet to be populated
+    cy.get('#character-sheet .role').should('have.length.greaterThan', 50);
+    
+    // Check for jinx entries
+    cy.get('#character-sheet .jinx-entry').should('exist');
+    
+    // Check that jinx entries have the expected structure
+    cy.get('#character-sheet .jinx-entry').first().within(() => {
+      cy.get('.jinx-characters').should('exist');
+      cy.get('.jinx-characters .icon').should('have.length', 2);
+      cy.get('.jinx-characters .name').should('have.length', 2);
+      cy.get('.jinx-plus').should('exist');
+      cy.get('.jinx-reason').should('exist');
+    });
+  });
+
+  it('displays jinx description when clicking on a jinx entry', () => {
+    // Load all characters which has jinxes
+    cy.get('#load-all-chars').click();
+    
+    // Wait for jinxes to appear
+    cy.get('#character-sheet .jinx-entry').should('exist');
+    
+    // Click on the first jinx entry
+    cy.get('#character-sheet .jinx-entry').first().click();
+    
+    // Check that jinx description is visible
+    cy.get('#character-sheet .jinx-entry').first()
+      .should('have.class', 'show-jinx-reason')
+      .find('.jinx-reason')
+      .should('be.visible');
+  });
+
+  it('toggles jinx description visibility on click', () => {
+    // Load all characters which has jinxes
+    cy.get('#load-all-chars').click();
+    
+    cy.get('#character-sheet .jinx-entry').should('exist');
+    
+    // Get the first jinx entry
+    cy.get('#character-sheet .jinx-entry').first().then($jinxEntry => {
+      // Initially, jinx reason should not be visible
+      cy.wrap($jinxEntry).find('.jinx-reason').should('not.be.visible');
+      cy.wrap($jinxEntry).should('not.have.class', 'show-jinx-reason');
+      
+      // Click the jinx entry (not the hidden reason)
+      cy.wrap($jinxEntry).click();
+      cy.wrap($jinxEntry).should('have.class', 'show-jinx-reason');
+      cy.wrap($jinxEntry).find('.jinx-reason').should('be.visible');
+      
+      // Click again to hide
+      cy.wrap($jinxEntry).click();
+      cy.wrap($jinxEntry).should('not.have.class', 'show-jinx-reason');
+      cy.wrap($jinxEntry).find('.jinx-reason').should('not.be.visible');
+    });
+  });
+
+  it('only displays jinxes for characters that are in the loaded script', () => {
+    // Load Trouble Brewing which has fewer characters with jinxes
+    cy.get('#load-tb').click();
+    
+    cy.get('#character-sheet .role').should('have.length.greaterThan', 0);
+    
+    // Check if jinxes section exists (TB might not have any jinxes)
+    cy.get('body').then($body => {
+      if ($body.find('#character-sheet h3.team-jinxes').length > 0) {
+        // If jinxes exist, verify they are only for characters in the script
+        cy.get('#character-sheet .jinx-entry').each($jinx => {
+          cy.wrap($jinx).find('.jinx-characters .name').should('have.length', 2);
+        });
+      } else {
+        // No jinxes section should exist if no applicable jinxes
+        cy.get('#character-sheet h3.team-jinxes').should('not.exist');
+      }
+    });
+  });
+});

--- a/tests/19_jinx_display.cy.js
+++ b/tests/19_jinx_display.cy.js
@@ -8,23 +8,40 @@ describe('Jinx Display', () => {
     });
   });
 
-  it('displays jinxes at the bottom of the script list after demons', () => {
+  it('displays jinxes section immediately after demons and before travellers/fabled', () => {
     // Load all characters which has jinxes
     cy.get('#load-all-chars').click();
     
     // Wait for character sheet to be populated
     cy.get('#character-sheet .role').should('have.length.greaterThan', 5);
     
-    // Check that jinxes section exists at the bottom after demons
+    // Check that jinxes section exists after demons
     cy.get('#character-sheet h3.team-demon').should('exist');
     cy.get('#character-sheet h3.team-jinxes').should('exist');
     
-    // Jinxes section should be after demons
+    // Jinxes section should be immediately after demons and before travellers/fabled
     cy.get('#character-sheet h3').then(($headers) => {
       const headers = $headers.toArray().map(el => el.textContent);
       const demonIndex = headers.indexOf('Demon');
       const jinxIndex = headers.indexOf('Jinxes');
+      const travellerIndex = headers.indexOf('Travellers');
+      const fabledIndex = headers.indexOf('Fabled');
+      
+      // Jinxes should be after demons
       expect(jinxIndex).to.be.greaterThan(demonIndex);
+      
+      // Jinxes should be immediately after demons (no other sections between)
+      expect(jinxIndex).to.equal(demonIndex + 1);
+      
+      // If travellers exist, jinxes should be before them
+      if (travellerIndex !== -1) {
+        expect(jinxIndex).to.be.lessThan(travellerIndex);
+      }
+      
+      // If fabled exist, jinxes should be before them
+      if (fabledIndex !== -1) {
+        expect(jinxIndex).to.be.lessThan(fabledIndex);
+      }
     });
   });
 


### PR DESCRIPTION
Add a 'Jinxes' section to the script list, displaying special rules between characters in the loaded script with interactive descriptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b9ac6fd-62c2-4aae-9daf-b94bdeab4b2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3b9ac6fd-62c2-4aae-9daf-b94bdeab4b2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

