### PR TITLE
Fix player name visibility on landscape

### DIFF
--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -20,3 +20,58 @@
     gap: 12px;
   }
 }
+
+/* Fix for landscape orientation - prevent player names from being cut off */
+@media (orientation: landscape) {
+  /* Adjust circle size to ensure player names fit within viewport */
+  .circle {
+    height: min(80vmin, calc(100vh - 160px));
+    width: min(80vmin, calc(100vw - 40px));
+  }
+  
+  /* Adjust player name positioning for better visibility on landscape */
+  .player-name.top-half {
+    /* Reduce the offset for top players to keep names visible */
+    top: calc(50% - var(--token-size) * 0.6);
+  }
+  
+  /* Also adjust bottom player names to maintain symmetry */
+  .player-name:not(.top-half) {
+    top: calc(50% + var(--token-size) * 0.6);
+  }
+  
+  /* Add some padding to the center container to ensure names don't get cut off */
+  #center {
+    padding: 20px 12px;
+  }
+}
+
+/* For very wide landscape viewports (tablets, desktops in landscape) */
+@media (orientation: landscape) and (min-aspect-ratio: 16/9) {
+  /* Further reduce offset for ultra-wide screens */
+  .player-name.top-half {
+    top: calc(50% - var(--token-size) * 0.5);
+  }
+  
+  .player-name:not(.top-half) {
+    top: calc(50% + var(--token-size) * 0.5);
+  }
+}
+
+/* For small landscape screens (phones in landscape) */
+@media (orientation: landscape) and (max-height: 500px) {
+  /* Further reduce circle size on very short landscape screens */
+  .circle {
+    height: min(75vmin, calc(100vh - 180px));
+    width: min(75vmin, calc(100vw - 40px));
+  }
+  
+  /* Even smaller offset for very limited vertical space */
+  .player-name.top-half {
+    top: calc(50% - var(--token-size) * 0.5);
+  }
+  
+  .player-name:not(.top-half) {
+    top: calc(50% + var(--token-size) * 0.5);
+  }
+}


### PR DESCRIPTION
Adjust player name positioning and container sizing to ensure visibility on character tokens in landscape mode.

In landscape orientation, the reduced vertical viewport height caused player names positioned above the character tokens to be cut off. This PR introduces responsive CSS adjustments to the `.circle` container height and width, modifies player name offsets, and adds padding to the `#center` container, with specific rules for ultra-wide and small landscape screens, to ensure player names are always visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e7553dd-4d19-4eba-ab24-5cf1437603b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e7553dd-4d19-4eba-ab24-5cf1437603b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

