### PR TITLE
Implement death vote indicator and player count display

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <div>
           <label for="player-count">Player Count:</label>
           <input type="number" id="player-count" min="5" max="20">
+          <span id="alive-count" style="margin-left: 10px; font-size: 0.9em; color: #999;"></span>
         </div>
         <button class="button" id="start-game">Start Game</button>
         <div id="game-status" class="status" aria-live="polite"></div>

--- a/src/character.js
+++ b/src/character.js
@@ -334,7 +334,7 @@ export function ensurePlayerContextMenu({ grimoireState }) {
     if (idx < 0) return;
     if (grimoireState.players.length >= 20) return; // clamp to max
     const newName = `Player ${grimoireState.players.length + 1}`;
-    const newPlayer = { name: newName, character: null, reminders: [], dead: false };
+    const newPlayer = { name: newName, character: null, reminders: [], dead: false, deathVote: false };
     grimoireState.players.splice(idx, 0, newPlayer);
     rebuildPlayerCircleUiPreserveState({ grimoireState });
   });
@@ -344,7 +344,7 @@ export function ensurePlayerContextMenu({ grimoireState }) {
     if (idx < 0) return;
     if (grimoireState.players.length >= 20) return; // clamp to max
     const newName = `Player ${grimoireState.players.length + 1}`;
-    const newPlayer = { name: newName, character: null, reminders: [], dead: false };
+    const newPlayer = { name: newName, character: null, reminders: [], dead: false, deathVote: false };
     grimoireState.players.splice(idx + 1, 0, newPlayer);
     rebuildPlayerCircleUiPreserveState({ grimoireState });
   });

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -5,7 +5,7 @@ import { BG_STORAGE_KEY, CLICK_EXPAND_SUPPRESS_MS, TOUCH_EXPAND_SUPPRESS_MS, isT
 import { snapshotCurrentGrimoire } from './history/grimoire.js';
 import { openReminderTokenModal, openTextReminderModal } from './reminder.js';
 import { positionRadialStack, repositionPlayers } from './ui/layout.js';
-import { createCurvedLabelSvg, createDeathRibbonSvg } from './ui/svg.js';
+import { createCurvedLabelSvg, createDeathRibbonSvg, createDeathVoteIndicatorSvg } from './ui/svg.js';
 import { positionInfoIcons, positionNightOrderNumbers, positionTooltip, showTouchAbilityPopup } from './ui/tooltip.js';
 import { getReminderTimestamp, isReminderVisible, updateDayNightUI, calculateNightOrder, shouldShowNightOrder, saveCurrentPhaseState } from './dayNightTracking.js';
 
@@ -41,7 +41,8 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
     name: `Player ${i + 1}`,
     character: null,
     reminders: [],
-    dead: false
+    dead: false,
+    deathVote: false
   }));
   if (playerCountInput) {
     try { playerCountInput.value = String(grimoireState.players.length); } catch (_) { }
@@ -312,6 +313,7 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
     updateGrimoire({ grimoireState });
     saveAppState({ grimoireState });
     renderSetupInfo({ grimoireState });
+    updateAliveCount({ grimoireState });
   });
 }
 
@@ -440,10 +442,24 @@ export function renderSetupInfo({ grimoireState }) {
   setupInfoEl.textContent = parts.join(' ');
 }
 
+function updateAliveCount({ grimoireState }) {
+  const aliveCountEl = document.getElementById('alive-count');
+  if (!aliveCountEl) return;
+  
+  const totalPlayers = grimoireState.players.length;
+  const alivePlayers = grimoireState.players.filter(player => !player.dead).length;
+  
+  aliveCountEl.textContent = `(${alivePlayers}/${totalPlayers} alive)`;
+}
+
 export function updateGrimoire({ grimoireState }) {
   const abilityTooltip = document.getElementById('ability-tooltip');
   const playerCircle = document.getElementById('player-circle');
   const listItems = playerCircle.querySelectorAll('li');
+  
+  // Update alive count display
+  updateAliveCount({ grimoireState });
+  
   listItems.forEach((li, i) => {
     const player = grimoireState.players[i];
     const playerNameEl = li.querySelector('.player-name');
@@ -554,7 +570,20 @@ export function updateGrimoire({ grimoireState }) {
     ribbon.classList.add('death-ribbon');
     const handleRibbonToggle = (e) => {
       e.stopPropagation();
-      grimoireState.players[i].dead = !grimoireState.players[i].dead;
+      const player = grimoireState.players[i];
+      
+      if (player.dead && player.deathVote) {
+        // If player is dead and has used death vote, revive them
+        grimoireState.players[i].dead = false;
+        grimoireState.players[i].deathVote = false;
+      } else {
+        // Otherwise, toggle dead state normally
+        grimoireState.players[i].dead = !grimoireState.players[i].dead;
+        // Reset death vote when marking alive
+        if (!grimoireState.players[i].dead) {
+          grimoireState.players[i].deathVote = false;
+        }
+      }
 
       // Save phase state if day/night tracking is enabled
       if (grimoireState.dayNightTracking && grimoireState.dayNightTracking.enabled) {
@@ -579,6 +608,30 @@ export function updateGrimoire({ grimoireState }) {
       tokenDiv.classList.add('is-dead');
     } else {
       tokenDiv.classList.remove('is-dead');
+    }
+
+    // Add death vote indicator for dead players
+    const existingDeathVote = tokenDiv.querySelector('.death-vote-indicator');
+    if (existingDeathVote) existingDeathVote.remove();
+    
+    if (player.dead && !player.deathVote) {
+      const deathVoteIndicator = createDeathVoteIndicatorSvg();
+      const handleDeathVoteClick = (e) => {
+        e.stopPropagation();
+        // Use death vote (can only be used once)
+        grimoireState.players[i].deathVote = true;
+        
+        // Save phase state if day/night tracking is enabled
+        if (grimoireState.dayNightTracking && grimoireState.dayNightTracking.enabled) {
+          saveCurrentPhaseState(grimoireState);
+        }
+        
+        updateGrimoire({ grimoireState });
+        saveAppState({ grimoireState });
+      };
+      
+      deathVoteIndicator.addEventListener('click', handleDeathVoteClick);
+      tokenDiv.appendChild(deathVoteIndicator);
     }
 
     // Add night order number if applicable
@@ -910,11 +963,12 @@ export function startGame({ grimoireState, grimoireHistoryList, playerCountInput
   const newPlayers = Array.from({ length: playerCount }, (_, i) => {
     const existing = existingPlayers[i];
     const name = existing && existing.name ? existing.name : `Player ${i + 1}`;
-    return { name, character: null, reminders: [], dead: false };
+    return { name, character: null, reminders: [], dead: false, deathVote: false };
   });
   grimoireState.players = newPlayers;
 
   rebuildPlayerCircleUiPreserveState({ grimoireState });
+  updateAliveCount({ grimoireState });
 
   // Reset day/night tracking when starting a new game
   try {
@@ -1231,6 +1285,7 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
   updateGrimoire({ grimoireState });
   saveAppState({ grimoireState });
   renderSetupInfo({ grimoireState });
+  updateAliveCount({ grimoireState });
   // Also after paint to ensure positions stabilize
   requestAnimationFrame(() => {
     repositionPlayers({ grimoireState });

--- a/src/ui/svg.js
+++ b/src/ui/svg.js
@@ -104,3 +104,32 @@ export function createDeathRibbonSvg() {
   return svg;
 }
 
+export function createDeathVoteIndicatorSvg() {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 100 100');
+  svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+  svg.classList.add('death-vote-indicator');
+  
+  // Create circle background
+  const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  circle.setAttribute('cx', '50');
+  circle.setAttribute('cy', '50');
+  circle.setAttribute('r', '40');
+  circle.setAttribute('fill', '#8B0000');
+  circle.setAttribute('stroke', '#000');
+  circle.setAttribute('stroke-width', '4');
+  
+  // Create vote symbol (checkmark)
+  const checkmark = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  checkmark.setAttribute('d', 'M 25 50 L 40 65 L 75 30');
+  checkmark.setAttribute('fill', 'none');
+  checkmark.setAttribute('stroke', '#FFF');
+  checkmark.setAttribute('stroke-width', '8');
+  checkmark.setAttribute('stroke-linecap', 'round');
+  checkmark.setAttribute('stroke-linejoin', 'round');
+  
+  svg.appendChild(circle);
+  svg.appendChild(checkmark);
+  return svg;
+}
+

--- a/styles/reminders.css
+++ b/styles/reminders.css
@@ -150,6 +150,24 @@
   opacity: 0.7;
 }
 
+/* Death vote indicator */
+.player-token .death-vote-indicator {
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  top: 5px;
+  right: 5px;
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+  z-index: 5;
+}
+
+.player-token .death-vote-indicator:hover {
+  opacity: 1;
+  transform: scale(1.1);
+}
+
 .icon-reminder-svg {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
Add a death vote indicator for dead players, allowing a single vote, and display the number of alive players.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea9b6cee-b29c-423b-8646-be7258f6ba7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea9b6cee-b29c-423b-8646-be7258f6ba7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

