### PR TITLE
Investigate safari overlap logic issues

### DIFF
--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -9,16 +9,40 @@ import { createCurvedLabelSvg, createDeathRibbonSvg, createDeathVoteIndicatorSvg
 import { positionInfoIcons, positionNightOrderNumbers, positionTooltip, showTouchAbilityPopup } from './ui/tooltip.js';
 import { getReminderTimestamp, isReminderVisible, updateDayNightUI, calculateNightOrder, shouldShowNightOrder, saveCurrentPhaseState } from './dayNightTracking.js';
 
+// Helper function to get accurate bounding rect accounting for iOS Safari viewport issues
+function getAccurateRect(element) {
+  const rect = element.getBoundingClientRect();
+  
+  // Check if visualViewport is available (for iOS Safari zoom/scroll compensation)
+  if (window.visualViewport) {
+    const scale = window.visualViewport.scale || 1;
+    const offsetLeft = window.visualViewport.offsetLeft || 0;
+    const offsetTop = window.visualViewport.offsetTop || 0;
+    
+    return {
+      left: rect.left * scale + offsetLeft,
+      right: rect.right * scale + offsetLeft,
+      top: rect.top * scale + offsetTop,
+      bottom: rect.bottom * scale + offsetTop,
+      width: rect.width * scale,
+      height: rect.height * scale
+    };
+  }
+  
+  // Fallback to standard getBoundingClientRect for browsers without visualViewport
+  return rect;
+}
+
 // Helper function to check if a player element is overlapping with another player
 function isPlayerOverlapping({ listItem }) {
-  const rect1 = listItem.getBoundingClientRect();
+  const rect1 = getAccurateRect(listItem);
   const allPlayers = document.querySelectorAll('#player-circle li');
   
   for (let i = 0; i < allPlayers.length; i++) {
     const otherPlayer = allPlayers[i];
     if (otherPlayer === listItem) continue;
     
-    const rect2 = otherPlayer.getBoundingClientRect();
+    const rect2 = getAccurateRect(otherPlayer);
     
     // Check if rectangles overlap
     const overlap = !(rect1.right < rect2.left || 

--- a/styles/utilities.css
+++ b/styles/utilities.css
@@ -9,6 +9,7 @@
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+  touch-action: manipulation; /* Prevents double-tap zoom on iOS */
 }
 
 #player-circle .player-token,
@@ -23,4 +24,5 @@
   -webkit-user-select: none;
   user-select: none;
   -webkit-touch-callout: none;
+  touch-action: manipulation; /* Prevents double-tap zoom on iOS */
 }


### PR DESCRIPTION
Fixes iOS Safari overlap detection and touch issues by using `visualViewport` for accurate element positioning and adding `touch-action: manipulation` to prevent unwanted zoom.

The `getBoundingClientRect()` method, crucial for overlap detection, returns incorrect values on iOS Safari when the page is zoomed or scrolled, leading to unreliable overlap calculations. Additionally, the lack of `touch-action: manipulation` can cause iOS Safari to interpret single taps as double-taps for zooming, interfering with custom touch event handling. These changes specifically address these iOS-specific quirks without affecting other browsers.

---
<a href="https://cursor.com/background-agent?bcId=bc-290f6246-7771-48dd-9279-ae32c431736c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-290f6246-7771-48dd-9279-ae32c431736c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>