### PR TITLE
Investigate safari iphone long press character token issue

### DIFF
--- a/src/bluffTokens.js
+++ b/src/bluffTokens.js
@@ -112,6 +112,37 @@ export function createBluffToken({ grimoireState, index }) {
     });
   }
   
+  // Add info icon for touch mode (initially hidden)
+  if (isTouchDevice) {
+    const infoIcon = document.createElement('div');
+    infoIcon.className = 'ability-info-icon bluff-info-icon';
+    infoIcon.innerHTML = '<i class="fas fa-info-circle"></i>';
+    infoIcon.dataset.bluffIndex = index;
+    infoIcon.style.display = 'none'; // Initially hidden
+    
+    // Handle both click and touch events
+    const handleInfoClick = (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const character = grimoireState.bluffs?.[index];
+      if (character) {
+        const role = grimoireState.allRoles[character];
+        if (role && role.ability) {
+          showTouchAbilityPopup(infoIcon, role.ability);
+        }
+      }
+    };
+    
+    infoIcon.onclick = handleInfoClick;
+    infoIcon.addEventListener('touchstart', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      handleInfoClick(e);
+    });
+    
+    token.appendChild(infoIcon);
+  }
+  
   return token;
 }
 
@@ -120,12 +151,7 @@ export function updateBluffToken({ grimoireState, index }) {
   if (!token) return;
   
   const character = grimoireState.bluffs?.[index];
-  
-  // Remove any existing info icon
-  const existingIcon = token.querySelector('.ability-info-icon');
-  if (existingIcon) {
-    existingIcon.remove();
-  }
+  const infoIcon = token.querySelector('.ability-info-icon');
   
   if (character && grimoireState.allRoles[character]) {
     const role = grimoireState.allRoles[character];
@@ -157,28 +183,9 @@ export function updateBluffToken({ grimoireState, index }) {
       label.style.display = 'none';
     }
     
-    // Add info icon for touch mode if role has ability
-    if (isTouchDevice && role.ability) {
-      const infoIcon = document.createElement('div');
-      infoIcon.className = 'ability-info-icon bluff-info-icon';
-      infoIcon.innerHTML = '<i class="fas fa-info-circle"></i>';
-      infoIcon.dataset.bluffIndex = index;
-      
-      // Handle both click and touch events
-      const handleInfoClick = (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        showTouchAbilityPopup(infoIcon, role.ability);
-      };
-      
-      infoIcon.onclick = handleInfoClick;
-      infoIcon.addEventListener('touchstart', (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        handleInfoClick(e);
-      });
-      
-      token.appendChild(infoIcon);
+    // Show/hide info icon based on whether role has ability
+    if (infoIcon) {
+      infoIcon.style.display = (isTouchDevice && role.ability) ? 'flex' : 'none';
     }
   } else {
     // Clear the token
@@ -200,6 +207,11 @@ export function updateBluffToken({ grimoireState, index }) {
     const label = token.querySelector('.bluff-label');
     if (label) {
       label.style.display = 'block';
+    }
+    
+    // Hide info icon when no character
+    if (infoIcon) {
+      infoIcon.style.display = 'none';
     }
   }
 }

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -156,8 +156,18 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
           `;
     playerCircle.appendChild(listItem);
 
+    // Track if a touch event has occurred to prevent click after touch
+    const tokenEl = listItem.querySelector('.player-token');
+    let touchOccurred = false;
+    
     // Only the main token area opens the character modal; ribbon handles dead toggle
-    listItem.querySelector('.player-token').onclick = (e) => {
+    tokenEl.onclick = (e) => {
+      // Ignore click if it was triggered by a touch event
+      if (touchOccurred) {
+        touchOccurred = false;
+        return;
+      }
+      
       const target = e.target;
       if (target && (target.closest('.death-ribbon') || target.classList.contains('death-ribbon'))) {
         return; // handled by ribbon click
@@ -170,9 +180,9 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
     
     // Add touchstart handler for player token with two-tap behavior
     if ('ontouchstart' in window) {
-      const tokenEl = listItem.querySelector('.player-token');
       let touchActionTimer = null;
       let isLongPress = false;
+      let touchStartTime = 0;
       
       tokenEl.addEventListener('touchstart', (e) => {
         const target = e.target;
@@ -183,6 +193,10 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
           return; // handled by info icon
         }
         
+        // Mark that a touch occurred
+        touchOccurred = true;
+        touchStartTime = Date.now();
+        
         // Reset long press flag
         isLongPress = false;
         
@@ -190,41 +204,49 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
         const x = e.touches[0].clientX;
         const y = e.touches[0].clientY;
         
-        // Start long press timer
+        // Clear any existing timers
         clearTimeout(grimoireState.longPressTimer);
+        clearTimeout(touchActionTimer);
+        
+        // Start long press timer
         grimoireState.longPressTimer = setTimeout(() => {
           isLongPress = true;
           clearTimeout(touchActionTimer);
           showPlayerContextMenu({ grimoireState, x, y, playerIndex: i });
         }, 600);
-        
-        // Delay the tap action slightly to allow long press detection
-        clearTimeout(touchActionTimer);
-        touchActionTimer = setTimeout(() => {
-          if (!isLongPress) {
-            handlePlayerElementTouch({
-              e,
-              listItem,
-              actionCallback: () => {
-                openCharacterModal({ grimoireState, playerIndex: i });
-              },
-              grimoireState,
-              playerIndex: i
-            });
-          }
-        }, 100);
       });
       
       tokenEl.addEventListener('touchend', (e) => {
         e.preventDefault();
-        // Clear timers if touch ends before long press
+        
+        // Calculate touch duration
+        const touchDuration = Date.now() - touchStartTime;
+        
+        // Clear long press timer
         clearTimeout(grimoireState.longPressTimer);
-        if (!isLongPress) {
-          // Let the delayed tap action execute
-        } else {
-          // Long press was triggered, cancel tap action
-          clearTimeout(touchActionTimer);
+        
+        // If it wasn't a long press and touch was quick enough, trigger the action
+        if (!isLongPress && touchDuration < 600) {
+          // Use a small delay to ensure long press timer is cancelled
+          touchActionTimer = setTimeout(() => {
+            if (!isLongPress) {
+              handlePlayerElementTouch({
+                e,
+                listItem,
+                actionCallback: () => {
+                  openCharacterModal({ grimoireState, playerIndex: i });
+                },
+                grimoireState,
+                playerIndex: i
+              });
+            }
+          }, 50);
         }
+        
+        // Reset touch flag after a delay to handle any delayed click events
+        setTimeout(() => {
+          touchOccurred = false;
+        }, 300);
       });
       
       tokenEl.addEventListener('touchcancel', (e) => {
@@ -232,6 +254,7 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
         clearTimeout(grimoireState.longPressTimer);
         clearTimeout(touchActionTimer);
         isLongPress = false;
+        touchOccurred = false;
       });
     }
     
@@ -1208,8 +1231,18 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
       `;
     playerCircle.appendChild(listItem);
 
+    // Track if a touch event has occurred to prevent click after touch
+    const tokenEl2 = listItem.querySelector('.player-token');
+    let touchOccurred2 = false;
+    
     // Open character modal on token click (unless clicking ribbon/info icon)
-    listItem.querySelector('.player-token').onclick = (e) => {
+    tokenEl2.onclick = (e) => {
+      // Ignore click if it was triggered by a touch event
+      if (touchOccurred2) {
+        touchOccurred2 = false;
+        return;
+      }
+      
       const target = e.target;
       if (target && (target.closest('.death-ribbon') || target.classList.contains('death-ribbon'))) {
         return;
@@ -1222,7 +1255,11 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
     
     // Add touchstart handler for player token with two-tap behavior
     if ('ontouchstart' in window) {
-      listItem.querySelector('.player-token').addEventListener('touchstart', (e) => {
+      let touchActionTimer2 = null;
+      let isLongPress2 = false;
+      let touchStartTime2 = 0;
+      
+      tokenEl2.addEventListener('touchstart', (e) => {
         const target = e.target;
         if (target && (target.closest('.death-ribbon') || target.classList.contains('death-ribbon'))) {
           return; // handled by ribbon
@@ -1231,15 +1268,68 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
           return; // handled by info icon
         }
         
-        handlePlayerElementTouch({
-          e,
-          listItem,
-          actionCallback: () => {
-            openCharacterModal({ grimoireState, playerIndex: i });
-          },
-          grimoireState,
-          playerIndex: i
-        });
+        // Mark that a touch occurred
+        touchOccurred2 = true;
+        touchStartTime2 = Date.now();
+        
+        // Reset long press flag
+        isLongPress2 = false;
+        
+        // Store touch start position for long press detection
+        const x = e.touches[0].clientX;
+        const y = e.touches[0].clientY;
+        
+        // Clear any existing timers
+        clearTimeout(grimoireState.longPressTimer);
+        clearTimeout(touchActionTimer2);
+        
+        // Start long press timer
+        grimoireState.longPressTimer = setTimeout(() => {
+          isLongPress2 = true;
+          clearTimeout(touchActionTimer2);
+          showPlayerContextMenu({ grimoireState, x, y, playerIndex: i });
+        }, 600);
+      });
+      
+      tokenEl2.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        
+        // Calculate touch duration
+        const touchDuration = Date.now() - touchStartTime2;
+        
+        // Clear long press timer
+        clearTimeout(grimoireState.longPressTimer);
+        
+        // If it wasn't a long press and touch was quick enough, trigger the action
+        if (!isLongPress2 && touchDuration < 600) {
+          // Use a small delay to ensure long press timer is cancelled
+          touchActionTimer2 = setTimeout(() => {
+            if (!isLongPress2) {
+              handlePlayerElementTouch({
+                e,
+                listItem,
+                actionCallback: () => {
+                  openCharacterModal({ grimoireState, playerIndex: i });
+                },
+                grimoireState,
+                playerIndex: i
+              });
+            }
+          }, 50);
+        }
+        
+        // Reset touch flag after a delay to handle any delayed click events
+        setTimeout(() => {
+          touchOccurred2 = false;
+        }, 300);
+      });
+      
+      tokenEl2.addEventListener('touchcancel', (e) => {
+        // Clear all timers on cancel
+        clearTimeout(grimoireState.longPressTimer);
+        clearTimeout(touchActionTimer2);
+        isLongPress2 = false;
+        touchOccurred2 = false;
       });
     }
 

--- a/styles/bluff-tokens.css
+++ b/styles/bluff-tokens.css
@@ -98,6 +98,31 @@
   }
 }
 
+/* Info icon for bluff tokens */
+.bluff-token .ability-info-icon {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 24px;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  cursor: pointer;
+  border: 2px solid #D4AF37;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+  z-index: 2;
+}
+
+.bluff-token .ability-info-icon:hover {
+  background: rgba(0, 0, 0, 0.9);
+  transform: scale(1.1);
+}
+
 /* Very small screens */
 @media (max-width: 480px) {
   .bluff-tokens-container {
@@ -109,5 +134,13 @@
   .bluff-token {
     width: 50px;
     height: 50px;
+  }
+  
+  .bluff-token .ability-info-icon {
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+    top: -6px;
+    right: -6px;
   }
 }

--- a/tests/18_player_two_tap_behavior.cy.js
+++ b/tests/18_player_two_tap_behavior.cy.js
@@ -42,6 +42,9 @@ describe('Player two-tap behavior in touch mode', () => {
     playerToken.trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });
     playerToken.trigger('touchend', { force: true });
     
+    // Wait for touch action to complete (50ms delay in implementation)
+    cy.wait(100);
+    
     // Check if raised or modal opened
     cy.get('body').then($body => {
       const modalVisible = $body.find('#character-modal:visible').length > 0;

--- a/tests/18_player_two_tap_behavior.cy.js
+++ b/tests/18_player_two_tap_behavior.cy.js
@@ -42,16 +42,20 @@ describe('Player two-tap behavior in touch mode', () => {
     playerToken.trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });
     playerToken.trigger('touchend', { force: true });
     
-    // Wait for touch action to complete (50ms delay in implementation)
-    cy.wait(100);
-    
-    // Check if raised or modal opened
-    cy.get('body').then($body => {
+    // Wait for either modal to become visible or player to be raised
+    // This is better than cy.wait because it waits only as long as needed
+    cy.get('body').should(($body) => {
       const modalVisible = $body.find('#character-modal:visible').length > 0;
       const playerRaised = $body.find('#player-circle li').eq(10).attr('data-raised') === 'true';
       
       // Either modal opened (not overlapping) or player raised (overlapping)
       expect(modalVisible || playerRaised).to.be.true;
+    });
+    
+    // Check the result and handle second tap if needed
+    cy.get('body').then($body => {
+      const modalVisible = $body.find('#character-modal:visible').length > 0;
+      const playerRaised = $body.find('#player-circle li').eq(10).attr('data-raised') === 'true';
       
       if (!modalVisible && playerRaised) {
         // Player was raised, so it was overlapping


### PR DESCRIPTION
Refactor touch event handling for player and bluff tokens to correctly distinguish between tap and long press on Safari iPhone.

Previously, conflicting `touchstart` and `pointerdown` handlers (and duplicate `touchstart` handlers for bluff tokens) caused the character modal to open immediately on any touch, even when a long press was intended for the context menu or ability tooltip. The fix introduces a short delay for tap actions, allowing long press detection to complete and cancel the tap if a long press is registered, ensuring the correct UI is displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-75dd9a99-aee4-4ee3-853c-bd096862d201">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75dd9a99-aee4-4ee3-853c-bd096862d201">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

