### PR TITLE
Investigate safari iphone menu disappearance on touch release

### DIFF
--- a/script.js
+++ b/script.js
@@ -101,18 +101,18 @@ document.addEventListener('DOMContentLoaded', () => {
     grimoireState.nightPhase = 'first-night';
   }
 
-    if (nightOrderSortCheckbox) {
+  if (nightOrderSortCheckbox) {
     nightOrderSortCheckbox.checked = grimoireState.nightOrderSort;
     if (nightOrderControls) {
       nightOrderControls.classList.toggle('active', grimoireState.nightOrderSort);
     }
-    
+
     nightOrderSortCheckbox.addEventListener('change', async () => {
       grimoireState.nightOrderSort = nightOrderSortCheckbox.checked;
       try {
         localStorage.setItem('nightOrderSort', grimoireState.nightOrderSort ? '1' : '0');
       } catch (_) {}
-      
+
       if (nightOrderControls) {
         nightOrderControls.classList.toggle('active', grimoireState.nightOrderSort);
       }
@@ -124,24 +124,24 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-    // Set up radio buttons
+  // Set up radio buttons
   if (firstNightBtn && otherNightsBtn) {
     // Set initial state
     firstNightBtn.checked = grimoireState.nightPhase === 'first-night';
     otherNightsBtn.checked = grimoireState.nightPhase === 'other-nights';
-    
+
     const handlePhaseChange = async (e) => {
       grimoireState.nightPhase = e.target.value;
       try {
         localStorage.setItem('nightPhase', grimoireState.nightPhase);
       } catch (_) {}
-      
+
       // Re-display the script with new phase
       if (grimoireState.scriptData && grimoireState.nightOrderSort) {
         await displayScript({ data: grimoireState.scriptData, grimoireState });
       }
     };
-    
+
     firstNightBtn.addEventListener('change', handlePhaseChange);
     otherNightsBtn.addEventListener('change', handlePhaseChange);
   }
@@ -229,7 +229,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Close modals by tapping outside content
-  characterModal.addEventListener('click', (e) => { 
+  characterModal.addEventListener('click', (e) => {
     if (e.target === characterModal) {
       characterModal.style.display = 'none';
       // Clear any bluff selection when closing

--- a/service-worker.js
+++ b/service-worker.js
@@ -123,7 +123,7 @@ self.addEventListener('fetch', event => {
     const tokenCachePromise = cacheAllTokenImages().catch(err => {
       console.error('Failed to cache token images:', err);
     });
-    
+
     event.respondWith(
       caches.match(event.request, { ignoreSearch: true })
         .then(response => {
@@ -160,7 +160,7 @@ self.addEventListener('fetch', event => {
             });
         })
     );
-    
+
     // Use waitUntil synchronously with the promise we created earlier
     event.waitUntil(tokenCachePromise);
     return;

--- a/src/bluffTokens.js
+++ b/src/bluffTokens.js
@@ -10,13 +10,13 @@ export function createBluffTokensContainer({ grimoireState }) {
   const container = document.createElement('div');
   container.id = 'bluff-tokens-container';
   container.className = 'bluff-tokens-container';
-  
+
   // Create 3 bluff token slots
   for (let i = 0; i < 3; i++) {
     const bluffToken = createBluffToken({ grimoireState, index: i });
     container.appendChild(bluffToken);
   }
-  
+
   return container;
 }
 
@@ -24,24 +24,24 @@ export function createBluffToken({ grimoireState, index }) {
   const token = document.createElement('div');
   token.className = 'bluff-token empty';
   token.dataset.bluffIndex = index;
-  
+
   // Set background image (empty token by default)
-  token.style.backgroundImage = `url('./assets/img/token-BqDQdWeO.webp')`;
+  token.style.backgroundImage = 'url(\'./assets/img/token-BqDQdWeO.webp\')';
   token.style.backgroundSize = 'cover';
   token.style.backgroundPosition = 'center';
   token.style.backgroundRepeat = 'no-repeat';
   token.style.position = 'relative';
   token.style.overflow = 'visible';
-  
+
   // Add label
   const label = document.createElement('div');
   label.className = 'bluff-label';
   label.textContent = `Bluff ${index + 1}`;
   token.appendChild(label);
-  
+
   // Track if a touch event has occurred to prevent click after touch
   let touchOccurred = false;
-  
+
   // Click handler
   token.addEventListener('click', (e) => {
     // Don't handle if clicking on info icon
@@ -56,7 +56,7 @@ export function createBluffToken({ grimoireState, index }) {
     e.stopPropagation();
     openBluffCharacterModal({ grimoireState, bluffIndex: index });
   });
-  
+
   // Hover handler for tooltips
   token.addEventListener('mouseenter', (e) => {
     const character = grimoireState.bluffs?.[index];
@@ -75,14 +75,14 @@ export function createBluffToken({ grimoireState, index }) {
       }
     }
   });
-  
+
   token.addEventListener('mouseleave', () => {
     const abilityTooltip = document.getElementById('ability-tooltip');
     if (abilityTooltip) {
       abilityTooltip.classList.remove('show');
     }
   });
-  
+
   // Simple touch handling - just prevent double click
   if (isTouchDevice) {
     token.addEventListener('touchstart', (e) => {
@@ -93,25 +93,25 @@ export function createBluffToken({ grimoireState, index }) {
       // Mark that a touch occurred to prevent click event
       touchOccurred = true;
     });
-    
+
     token.addEventListener('touchend', (e) => {
       // Don't handle if clicking on info icon
       if (e.target.closest('.ability-info-icon')) {
         return;
       }
-      
+
       e.preventDefault();
-      
+
       // Trigger the modal opening
       openBluffCharacterModal({ grimoireState, bluffIndex: index });
-      
+
       // Reset touch flag after a delay to handle any delayed click events
       setTimeout(() => {
         touchOccurred = false;
       }, 300);
     });
   }
-  
+
   // Add info icon for touch mode (initially hidden)
   if (isTouchDevice) {
     const infoIcon = document.createElement('div');
@@ -119,7 +119,7 @@ export function createBluffToken({ grimoireState, index }) {
     infoIcon.innerHTML = '<i class="fas fa-info-circle"></i>';
     infoIcon.dataset.bluffIndex = index;
     infoIcon.style.display = 'none'; // Initially hidden
-    
+
     // Handle both click and touch events
     const handleInfoClick = (e) => {
       e.stopPropagation();
@@ -132,35 +132,35 @@ export function createBluffToken({ grimoireState, index }) {
         }
       }
     };
-    
+
     infoIcon.onclick = handleInfoClick;
     infoIcon.addEventListener('touchstart', (e) => {
       e.stopPropagation();
       e.preventDefault();
       handleInfoClick(e);
     });
-    
+
     token.appendChild(infoIcon);
   }
-  
+
   return token;
 }
 
 export function updateBluffToken({ grimoireState, index }) {
   const token = document.querySelector(`[data-bluff-index="${index}"]`);
   if (!token) return;
-  
+
   const character = grimoireState.bluffs?.[index];
   const infoIcon = token.querySelector('.ability-info-icon');
-  
+
   if (character && grimoireState.allRoles[character]) {
     const role = grimoireState.allRoles[character];
-    
+
     // Update appearance
     token.classList.remove('empty');
     token.classList.add('has-character');
     token.dataset.character = character;
-    
+
     // Set character image with fallback
     const characterImage = role.image || './assets/img/token-BqDQdWeO.webp';
     token.style.backgroundImage = `url('${characterImage}'), url('./assets/img/token-BqDQdWeO.webp')`;
@@ -168,7 +168,7 @@ export function updateBluffToken({ grimoireState, index }) {
     token.style.backgroundPosition = 'center, center';
     token.style.backgroundRepeat = 'no-repeat, no-repeat';
     token.style.backgroundColor = 'transparent';
-    
+
     // Update or create curved label
     let svg = token.querySelector('svg');
     if (svg) {
@@ -176,13 +176,13 @@ export function updateBluffToken({ grimoireState, index }) {
     }
     svg = createCurvedLabelSvg(`bluff-role-arc-${character}`, role.name);
     token.appendChild(svg);
-    
+
     // Remove the default label when character is assigned
     const label = token.querySelector('.bluff-label');
     if (label) {
       label.style.display = 'none';
     }
-    
+
     // Show/hide info icon based on whether role has ability
     if (infoIcon) {
       infoIcon.style.display = (isTouchDevice && role.ability) ? 'flex' : 'none';
@@ -192,23 +192,23 @@ export function updateBluffToken({ grimoireState, index }) {
     token.classList.add('empty');
     token.classList.remove('has-character');
     delete token.dataset.character;
-    
+
     // Reset to empty token appearance
-    token.style.backgroundImage = `url('./assets/img/token-BqDQdWeO.webp')`;
+    token.style.backgroundImage = 'url(\'./assets/img/token-BqDQdWeO.webp\')';
     token.style.backgroundSize = 'cover';
-    
+
     // Remove any curved label
     const svg = token.querySelector('svg');
     if (svg) {
       svg.remove();
     }
-    
+
     // Show the default label
     const label = token.querySelector('.bluff-label');
     if (label) {
       label.style.display = 'block';
     }
-    
+
     // Hide info icon when no character
     if (infoIcon) {
       infoIcon.style.display = 'none';
@@ -220,16 +220,16 @@ export function openBluffCharacterModal({ grimoireState, bluffIndex }) {
   const characterModal = document.getElementById('character-modal');
   const characterModalPlayerName = document.getElementById('character-modal-player-name');
   const characterSearch = document.getElementById('character-search');
-  
+
   if (!grimoireState.scriptData) {
     alert('Please load a script first.');
     return;
   }
-  
+
   // Store the bluff index in grimoire state temporarily
   grimoireState.selectedBluffIndex = bluffIndex;
   // Don't modify selectedPlayerIndex - it should remain as is
-  
+
   // Update modal title
   const modalTitle = characterModal.querySelector('h3');
   if (modalTitle) {
@@ -238,7 +238,7 @@ export function openBluffCharacterModal({ grimoireState, bluffIndex }) {
   if (characterModalPlayerName) {
     characterModalPlayerName.textContent = '';
   }
-  
+
   populateCharacterGrid({ grimoireState });
   characterModal.style.display = 'flex';
   characterSearch.value = '';
@@ -247,25 +247,25 @@ export function openBluffCharacterModal({ grimoireState, bluffIndex }) {
 
 export function assignBluffCharacter({ grimoireState, roleId }) {
   const characterModal = document.getElementById('character-modal');
-  
+
   if (grimoireState.selectedBluffIndex !== undefined && grimoireState.selectedBluffIndex > -1) {
     // Initialize bluffs array if it doesn't exist
     if (!grimoireState.bluffs) {
       grimoireState.bluffs = [null, null, null];
     }
-    
+
     // Assign the character to the bluff slot
     grimoireState.bluffs[grimoireState.selectedBluffIndex] = roleId;
-    
+
     // Update the bluff token display
     updateBluffToken({ grimoireState, index: grimoireState.selectedBluffIndex });
-    
+
     // Hide the modal
     characterModal.style.display = 'none';
-    
+
     // Clear bluff selection
     delete grimoireState.selectedBluffIndex;
-    
+
     // Save state
     saveAppState({ grimoireState });
   }

--- a/src/bluffTokens.js
+++ b/src/bluffTokens.js
@@ -1,4 +1,4 @@
-import { resolveAssetPath } from '../utils.js';
+
 import { createCurvedLabelSvg } from './ui/svg.js';
 import { positionTooltip, showTouchAbilityPopup } from './ui/tooltip.js';
 import { populateCharacterGrid } from './character.js';
@@ -58,7 +58,7 @@ export function createBluffToken({ grimoireState, index }) {
   });
 
   // Hover handler for tooltips
-  token.addEventListener('mouseenter', (e) => {
+  token.addEventListener('mouseenter', (_e) => {
     const character = grimoireState.bluffs?.[index];
     if (character) {
       const role = grimoireState.allRoles[character];

--- a/src/character.js
+++ b/src/character.js
@@ -16,7 +16,7 @@ export function populateCharacterGrid({ grimoireState }) {
   if (!filter || ['none', 'clear', 'empty'].some(term => term.includes(filter))) {
     const emptyToken = document.createElement('div');
     emptyToken.className = 'token empty';
-    emptyToken.style.backgroundImage = `url('./assets/img/token-BqDQdWeO.webp')`;
+    emptyToken.style.backgroundImage = 'url(\'./assets/img/token-BqDQdWeO.webp\')';
     emptyToken.style.backgroundSize = 'cover';
     emptyToken.style.position = 'relative';
     emptyToken.style.overflow = 'visible';
@@ -51,13 +51,13 @@ export function populateCharacterGrid({ grimoireState }) {
 
 export function assignCharacter({ grimoireState, roleId }) {
   const characterModal = document.getElementById('character-modal');
-  
+
   // Check if this is for a bluff token
   if (grimoireState.selectedBluffIndex !== undefined && grimoireState.selectedBluffIndex > -1) {
     assignBluffCharacter({ grimoireState, roleId });
     return;
   }
-  
+
   // Original player assignment logic
   if (grimoireState.selectedPlayerIndex > -1) {
     grimoireState.players[grimoireState.selectedPlayerIndex].character = roleId;
@@ -218,14 +218,14 @@ export function openCharacterModal({ grimoireState, playerIndex }) {
     return;
   }
   grimoireState.selectedPlayerIndex = playerIndex;
-  
+
   // Update modal title back to player selection
   const modalTitle = characterModal.querySelector('h3');
   if (modalTitle && characterModalPlayerName) {
     modalTitle.textContent = 'Select Character for ';
     characterModalPlayerName.textContent = grimoireState.players[playerIndex].name;
   }
-  
+
   populateCharacterGrid({ grimoireState });
   characterModal.style.display = 'flex';
   characterSearch.value = '';

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -222,8 +222,10 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
         // Calculate touch duration
         const touchDuration = Date.now() - touchStartTime;
         
-        // Clear long press timer
-        clearTimeout(grimoireState.longPressTimer);
+        // Clear long press timer only if menu is not already visible
+        if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
+          clearTimeout(grimoireState.longPressTimer);
+        }
         
         // If it wasn't a long press and touch was quick enough, trigger the action
         if (!isLongPress && touchDuration < 600) {
@@ -250,8 +252,10 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
       });
       
       tokenEl.addEventListener('touchcancel', (e) => {
-        // Clear all timers on cancel
-        clearTimeout(grimoireState.longPressTimer);
+        // Clear all timers on cancel (only clear long press timer if menu is not visible)
+        if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
+          clearTimeout(grimoireState.longPressTimer);
+        }
         clearTimeout(touchActionTimer);
         isLongPress = false;
         touchOccurred = false;
@@ -957,7 +961,13 @@ export function updateGrimoire({ grimoireState }) {
               showReminderContextMenu({ grimoireState, x, y, playerIndex: i, reminderIndex: idx });
             }, 600);
           };
-          const onPressEnd = () => { clearTimeout(grimoireState.longPressTimer); try { iconEl.classList.remove('press-feedback'); } catch (_) { } };
+          const onPressEnd = () => { 
+            // Only clear the timer if the reminder menu is not already visible
+            if (!grimoireState.reminderContextMenu || grimoireState.reminderContextMenu.style.display !== 'block') {
+              clearTimeout(grimoireState.longPressTimer);
+            }
+            try { iconEl.classList.remove('press-feedback'); } catch (_) { } 
+          };
           iconEl.addEventListener('pointerdown', onPressStart);
           iconEl.addEventListener('pointerup', onPressEnd);
           iconEl.addEventListener('pointercancel', onPressEnd);
@@ -1091,7 +1101,13 @@ export function updateGrimoire({ grimoireState }) {
               showReminderContextMenu({ grimoireState, x, y, playerIndex: i, reminderIndex: idx });
             }, 600);
           };
-          const onPressEnd2 = () => { clearTimeout(grimoireState.longPressTimer); try { reminderEl.classList.remove('press-feedback'); } catch (_) { } };
+          const onPressEnd2 = () => { 
+            // Only clear the timer if the reminder menu is not already visible
+            if (!grimoireState.reminderContextMenu || grimoireState.reminderContextMenu.style.display !== 'block') {
+              clearTimeout(grimoireState.longPressTimer);
+            }
+            try { reminderEl.classList.remove('press-feedback'); } catch (_) { } 
+          };
           reminderEl.addEventListener('pointerdown', onPressStart2);
           reminderEl.addEventListener('pointerup', onPressEnd2);
           reminderEl.addEventListener('pointercancel', onPressEnd2);
@@ -1297,8 +1313,10 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
         // Calculate touch duration
         const touchDuration = Date.now() - touchStartTime2;
         
-        // Clear long press timer
-        clearTimeout(grimoireState.longPressTimer);
+        // Clear long press timer only if menu is not already visible
+        if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
+          clearTimeout(grimoireState.longPressTimer);
+        }
         
         // If it wasn't a long press and touch was quick enough, trigger the action
         if (!isLongPress2 && touchDuration < 600) {
@@ -1325,8 +1343,10 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
       });
       
       tokenEl2.addEventListener('touchcancel', (e) => {
-        // Clear all timers on cancel
-        clearTimeout(grimoireState.longPressTimer);
+        // Clear all timers on cancel (only clear long press timer if menu is not visible)
+        if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
+          clearTimeout(grimoireState.longPressTimer);
+        }
         clearTimeout(touchActionTimer2);
         isLongPress2 = false;
         touchOccurred2 = false;
@@ -1480,7 +1500,12 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
       }, 600);
     });
     ['pointerup', 'pointercancel', 'pointerleave'].forEach(evt => {
-      tokenEl.addEventListener(evt, () => { clearTimeout(grimoireState.longPressTimer); });
+      tokenEl.addEventListener(evt, () => { 
+        // Only clear the timer if the menu is not already visible
+        if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
+          clearTimeout(grimoireState.longPressTimer);
+        }
+      });
     });
 
     // Install one-time outside collapse handler for touch devices

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -67,7 +67,7 @@ function isPlayerOverlapping({ listItem }) {
 }
 
 // Helper function to handle two-tap behavior for any element within a player
-function handlePlayerElementTouch({ e, listItem, actionCallback, grimoireState, playerIndex }) {
+function handlePlayerElementTouch({ e, listItem, actionCallback }) {
   if (!('ontouchstart' in window)) return;
 
   e.stopPropagation();
@@ -251,7 +251,7 @@ export function setupGrimoire({ grimoireState, grimoireHistoryList, count }) {
         }, 300);
       });
 
-      tokenEl.addEventListener('touchcancel', (e) => {
+      tokenEl.addEventListener('touchcancel', (_e) => {
         // Clear all timers on cancel (only clear long press timer if menu is not visible)
         if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
           clearTimeout(grimoireState.longPressTimer);
@@ -1341,7 +1341,7 @@ export function rebuildPlayerCircleUiPreserveState({ grimoireState }) {
         }, 300);
       });
 
-      tokenEl2.addEventListener('touchcancel', (e) => {
+      tokenEl2.addEventListener('touchcancel', (_e) => {
         // Clear all timers on cancel (only clear long press timer if menu is not visible)
         if (!grimoireState.playerContextMenu || grimoireState.playerContextMenu.style.display !== 'block') {
           clearTimeout(grimoireState.longPressTimer);

--- a/src/history/exportImport.js
+++ b/src/history/exportImport.js
@@ -14,18 +14,18 @@ export function exportHistory() {
   // Create blob and download
   const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
-  
+
   // Create download link
   const a = document.createElement('a');
   a.href = url;
   const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
   a.download = `botc-history-${date}.json`;
-  
+
   // Trigger download
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  
+
   // Clean up
   URL.revokeObjectURL(url);
 
@@ -34,7 +34,7 @@ export function exportHistory() {
   if (importStatus) {
     const scriptCount = exportData.scriptHistory.length;
     const grimoireCount = exportData.grimoireHistory.length;
-    
+
     let message = 'History exported successfully! ';
     const parts = [];
     if (scriptCount > 0) {
@@ -43,16 +43,16 @@ export function exportHistory() {
     if (grimoireCount > 0) {
       parts.push(`${grimoireCount} grimoire${grimoireCount !== 1 ? 's' : ''}`);
     }
-    
+
     if (parts.length > 0) {
       message += `Exported ${parts.join(' and ')}.`;
     } else {
       message += 'Exported empty history.';
     }
-    
+
     importStatus.textContent = message;
     importStatus.className = 'status';
-    
+
     // Clear the message after 5 seconds
     setTimeout(() => {
       importStatus.textContent = '';
@@ -132,7 +132,7 @@ export async function importHistory(file) {
 
     for (const importedEntry of data.scriptHistory) {
       // Check if this exact entry already exists
-      const isDuplicate = history.scriptHistory.some(existingEntry => 
+      const isDuplicate = history.scriptHistory.some(existingEntry =>
         areEntriesIdentical(existingEntry, importedEntry)
       );
 
@@ -159,7 +159,7 @@ export async function importHistory(file) {
 
     for (const importedEntry of data.grimoireHistory) {
       // Check if this exact entry already exists
-      const isDuplicate = history.grimoireHistory.some(existingEntry => 
+      const isDuplicate = history.grimoireHistory.some(existingEntry =>
         areGrimoireEntriesIdentical(existingEntry, importedEntry)
       );
 
@@ -190,10 +190,10 @@ export async function importHistory(file) {
     // Re-render history lists
     const { renderScriptHistory } = await import('./script.js');
     const { renderGrimoireHistory } = await import('./grimoire.js');
-    
+
     const scriptHistoryList = document.getElementById('script-history-list');
     const grimoireHistoryList = document.getElementById('grimoire-history-list');
-    
+
     if (scriptHistoryList) {
       renderScriptHistory({ scriptHistoryList });
     }
@@ -206,7 +206,7 @@ export async function importHistory(file) {
     if (importStatus) {
       const scriptCount = processedScriptHistory.length;
       const grimoireCount = processedGrimoireHistory.length;
-      
+
       let message = 'History imported successfully! ';
       if (scriptCount > 0 || grimoireCount > 0) {
         const parts = [];
@@ -220,10 +220,10 @@ export async function importHistory(file) {
       } else {
         message += 'No new entries added (all were duplicates).';
       }
-      
+
       importStatus.textContent = message;
       importStatus.className = 'status';
-      
+
       // Clear the message after 5 seconds
       setTimeout(() => {
         importStatus.textContent = '';
@@ -264,7 +264,7 @@ export function initExportImport() {
           importStatus.textContent = '';
           importStatus.className = '';
         }
-        
+
         try {
           await importHistory(file);
           // Clear the input so the same file can be selected again

--- a/src/history/exportImport.js
+++ b/src/history/exportImport.js
@@ -269,7 +269,7 @@ export function initExportImport() {
           await importHistory(file);
           // Clear the input so the same file can be selected again
           importFileInput.value = '';
-        } catch (error) {
+        } catch (_error) {
           // Error already handled in importHistory
         }
       }

--- a/src/ui/svg.js
+++ b/src/ui/svg.js
@@ -109,7 +109,7 @@ export function createDeathVoteIndicatorSvg() {
   svg.setAttribute('viewBox', '0 0 100 100');
   svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
   svg.classList.add('death-vote-indicator');
-  
+
   // Create circle background
   const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
   circle.setAttribute('cx', '50');
@@ -118,7 +118,7 @@ export function createDeathVoteIndicatorSvg() {
   circle.setAttribute('fill', '#8B0000');
   circle.setAttribute('stroke', '#000');
   circle.setAttribute('stroke-width', '4');
-  
+
   // Create vote symbol (checkmark)
   const checkmark = document.createElementNS('http://www.w3.org/2000/svg', 'path');
   checkmark.setAttribute('d', 'M 25 50 L 40 65 L 75 30');
@@ -127,7 +127,7 @@ export function createDeathVoteIndicatorSvg() {
   checkmark.setAttribute('stroke-width', '8');
   checkmark.setAttribute('stroke-linecap', 'round');
   checkmark.setAttribute('stroke-linejoin', 'round');
-  
+
   svg.appendChild(circle);
   svg.appendChild(checkmark);
   return svg;

--- a/tests/03_tour.cy.js
+++ b/tests/03_tour.cy.js
@@ -15,7 +15,7 @@ describe('Tour', () => {
     cy.get('#start-game').click();
     cy.get('#load-tb').click();
     cy.get('#load-status', { timeout: 10000 }).should('contain', 'successfully');
-    
+
     // Start the tour
     cy.get('#start-tour').click();
 
@@ -70,7 +70,7 @@ describe('Tour', () => {
     cy.get('#start-game').click();
     cy.get('#load-tb').click();
     cy.get('#load-status', { timeout: 10000 }).should('contain', 'successfully');
-    
+
     // Start the tour
     cy.get('#start-tour').click();
 
@@ -114,7 +114,7 @@ describe('Tour', () => {
     cy.get('#start-game').click();
     cy.get('#load-tb').click();
     cy.get('#load-status', { timeout: 10000 }).should('contain', 'successfully');
-    
+
     // Start the tour
     cy.get('#start-tour').click();
 
@@ -134,7 +134,7 @@ describe('Tour', () => {
 
     // Verify the highlight is on a player token or the player circle
     cy.get('.tour-highlight').should('exist');
-    
+
     // Verify we can navigate back and forward
     cy.contains('.tour-popover .actions .button', 'Back').click();
     cy.get('.tour-popover .title').should('contain', 'Assign a character');

--- a/tests/06_sidebar_and_state.cy.js
+++ b/tests/06_sidebar_and_state.cy.js
@@ -108,7 +108,7 @@ describe('Sidebar & State', () => {
 
     // Find the character sheet section
     cy.get('#character-sheet').should('exist');
-    
+
     // Find the background section
     cy.get('#sidebar').within(() => {
       cy.contains('h3', 'Background').should('exist');
@@ -117,10 +117,10 @@ describe('Sidebar & State', () => {
     // Verify that the background section comes after the character sheet
     cy.get('#character-sheet').then(($charSheet) => {
       const charSheetBottom = $charSheet[0].getBoundingClientRect().bottom;
-      
+
       cy.get('#sidebar').contains('h3', 'Background').then(($bgHeader) => {
         const bgTop = $bgHeader[0].getBoundingClientRect().top;
-        
+
         // Background section should appear below the character sheet
         expect(bgTop).to.be.greaterThan(charSheetBottom);
       });

--- a/tests/08_touch_and_tooltips.cy.js
+++ b/tests/08_touch_and_tooltips.cy.js
@@ -168,7 +168,7 @@ describe('Ability UI - Touch', () => {
         players[0].style.left = '100px';
         players[0].style.top = '100px';
         players[0].style.zIndex = '10';
-        
+
         players[1].style.position = 'absolute';
         players[1].style.left = '120px'; // Overlapping position
         players[1].style.top = '120px';

--- a/tests/18_player_two_tap_behavior.cy.js
+++ b/tests/18_player_two_tap_behavior.cy.js
@@ -36,7 +36,6 @@ describe('Player two-tap behavior in touch mode', () => {
 
     // Find a player in the middle of the circle (likely to overlap)
     const playerToken = cy.get('#player-circle li').eq(10).find('.player-token');
-    const playerLi = cy.get('#player-circle li').eq(10);
 
     // First tap
     playerToken.trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });

--- a/tests/18_player_two_tap_behavior.cy.js
+++ b/tests/18_player_two_tap_behavior.cy.js
@@ -2,20 +2,20 @@ describe('Player two-tap behavior in touch mode', () => {
   beforeEach(() => {
     cy.viewport(800, 600);
     cy.visit('/');
-    cy.window().then((win) => { 
-      try { win.localStorage.clear(); } catch (_) {} 
+    cy.window().then((win) => {
+      try { win.localStorage.clear(); } catch (_) {}
     });
     cy.reload();
-    
+
     // Force touch mode
     cy.window().then((win) => {
       Object.defineProperty(win, 'ontouchstart', { value: true, configurable: true });
     });
-    
+
     // Load script and start game with many players
     cy.get('#load-tb').click({ force: true });
     cy.get('#character-sheet .role').should('have.length.greaterThan', 5);
-    
+
     // Start with 20 players to ensure overlaps
     cy.get('#player-count').then(($el) => {
       const el = $el[0];
@@ -33,30 +33,30 @@ describe('Player two-tap behavior in touch mode', () => {
     // - First tap on overlapping player raises it
     // - Second tap performs the action
     // - Only one player can be raised at a time
-    
+
     // Find a player in the middle of the circle (likely to overlap)
     const playerToken = cy.get('#player-circle li').eq(10).find('.player-token');
     const playerLi = cy.get('#player-circle li').eq(10);
-    
+
     // First tap
     playerToken.trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });
     playerToken.trigger('touchend', { force: true });
-    
+
     // Wait for either modal to become visible or player to be raised
     // This is better than cy.wait because it waits only as long as needed
     cy.get('body').should(($body) => {
       const modalVisible = $body.find('#character-modal:visible').length > 0;
       const playerRaised = $body.find('#player-circle li').eq(10).attr('data-raised') === 'true';
-      
+
       // Either modal opened (not overlapping) or player raised (overlapping)
       expect(modalVisible || playerRaised).to.be.true;
     });
-    
+
     // Check the result and handle second tap if needed
     cy.get('body').then($body => {
       const modalVisible = $body.find('#character-modal:visible').length > 0;
       const playerRaised = $body.find('#player-circle li').eq(10).attr('data-raised') === 'true';
-      
+
       if (!modalVisible && playerRaised) {
         // Player was raised, so it was overlapping
         // Second tap should open modal
@@ -71,13 +71,13 @@ describe('Player two-tap behavior in touch mode', () => {
     // Try multiple players to find overlapping ones
     let firstRaisedIndex = -1;
     let secondRaisedIndex = -1;
-    
+
     // Try to raise first player
     cy.wrap([5, 7, 9, 11, 13]).each((index) => {
       if (firstRaisedIndex === -1) {
         cy.get('#player-circle li').eq(index).find('.player-token').trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });
         cy.get('#player-circle li').eq(index).find('.player-token').trigger('touchend', { force: true });
-        
+
         cy.get('#player-circle li').eq(index).then($li => {
           if ($li.attr('data-raised') === 'true') {
             firstRaisedIndex = index;
@@ -91,7 +91,7 @@ describe('Player two-tap behavior in touch mode', () => {
           if (secondRaisedIndex === -1 && index !== firstRaisedIndex) {
             cy.get('#player-circle li').eq(index).find('.player-token').trigger('touchstart', { force: true, touches: [{ clientX: 10, clientY: 10 }] });
             cy.get('#player-circle li').eq(index).find('.player-token').trigger('touchend', { force: true });
-            
+
             cy.get('#player-circle li').eq(index).then($li => {
               if ($li.attr('data-raised') === 'true') {
                 secondRaisedIndex = index;

--- a/tests/20_night_order_sorting.cy.js
+++ b/tests/20_night_order_sorting.cy.js
@@ -171,7 +171,7 @@ describe('Night Order Sorting', () => {
     });
   });
 
-    describe('Night Phase Selector', () => {
+  describe('Night Phase Selector', () => {
     it('should show night phase selector only when night order sorting is enabled', () => {
       // Initially hidden
       cy.get('[data-testid="night-phase-selector"]').should('not.be.visible');

--- a/tests/21_traveler_player_count_adjustment.cy.js
+++ b/tests/21_traveler_player_count_adjustment.cy.js
@@ -40,46 +40,46 @@ describe('Traveler Player Count Adjustment', () => {
 
   it('should adjust setup to 11 players when one traveler is assigned', () => {
     startGameWithPlayers(12);
-    
+
     // Initially should show 12 player setup
     cy.get('#setup-info').should('contain', '7/2/2/1');
-    
+
     // Assign a traveler to first player
     assignCharacterToPlayer(0, 'Beggar');
-    
+
     // Setup should now show 11 player setup (7/1/2/1)
     cy.get('#setup-info').should('contain', '7/1/2/1');
   });
 
   it('should adjust setup to 10 players when two travelers are assigned', () => {
     startGameWithPlayers(12);
-    
+
     // Initially should show 12 player setup
     cy.get('#setup-info').should('contain', '7/2/2/1');
-    
+
     // Assign travelers to first two players
     assignCharacterToPlayer(0, 'Beggar');
     assignCharacterToPlayer(1, 'Bureaucrat');
-    
+
     // Setup should now show 10 player setup (7/0/2/1)
     cy.get('#setup-info').should('contain', '7/0/2/1');
   });
 
   it('should handle mixed regular characters and travelers correctly', () => {
     startGameWithPlayers(12);
-    
+
     // Assign regular character
     assignCharacterToPlayer(0, 'Washerwoman');
     cy.get('#setup-info').should('contain', '7/2/2/1');
-    
+
     // Assign traveler
     assignCharacterToPlayer(1, 'Beggar');
     cy.get('#setup-info').should('contain', '7/1/2/1');
-    
+
     // Assign another regular character
     assignCharacterToPlayer(2, 'Chef');
     cy.get('#setup-info').should('contain', '7/1/2/1');
-    
+
     // Assign another traveler
     assignCharacterToPlayer(3, 'Bureaucrat');
     cy.get('#setup-info').should('contain', '7/0/2/1');
@@ -87,11 +87,11 @@ describe('Traveler Player Count Adjustment', () => {
 
   it('should update when traveler is removed', () => {
     startGameWithPlayers(12);
-    
+
     // Assign a traveler
     assignCharacterToPlayer(0, 'Beggar');
     cy.get('#setup-info').should('contain', '7/1/2/1');
-    
+
     // Remove the traveler by assigning nothing
     cy.get('#player-circle li .player-token').eq(0).click({ force: true });
     cy.get('#character-modal').should('be.visible');
@@ -103,17 +103,17 @@ describe('Traveler Player Count Adjustment', () => {
     });
     cy.get('#character-grid .token.empty').should('exist').first().click();
     cy.get('#character-modal').should('not.be.visible');
-    
+
     // Setup should return to 12 player setup
     cy.get('#setup-info').should('contain', '7/2/2/1');
   });
 
   it('should handle edge cases with very small games', () => {
     startGameWithPlayers(5);
-    
+
     // 5 player game normally shows 3/0/1/1
     cy.get('#setup-info').should('contain', '3/0/1/1');
-    
+
     // Assign one traveler - should show 4 player setup which doesn't exist
     // So it should show no setup numbers
     assignCharacterToPlayer(0, 'Beggar');
@@ -123,18 +123,18 @@ describe('Traveler Player Count Adjustment', () => {
 
   it('should work correctly after character changes', () => {
     startGameWithPlayers(10);
-    
+
     // 10 player game shows 7/0/2/1
     cy.get('#setup-info').should('contain', '7/0/2/1');
-    
+
     // Change first player from regular to traveler
     assignCharacterToPlayer(0, 'Washerwoman');
     cy.get('#setup-info').should('contain', '7/0/2/1');
-    
+
     // Change same player to traveler
     assignCharacterToPlayer(0, 'Beggar');
     cy.get('#setup-info').should('contain', '5/2/1/1'); // 9 player setup
-    
+
     // Change back to regular
     assignCharacterToPlayer(0, 'Chef');
     cy.get('#setup-info').should('contain', '7/0/2/1'); // Back to 10 player

--- a/tests/22_history_export_import.cy.js
+++ b/tests/22_history_export_import.cy.js
@@ -11,15 +11,15 @@ describe('History Export/Import', () => {
   it('should show export and import buttons in the UI', () => {
     // Scroll to the History Management section
     cy.contains('h3', 'History Management').scrollIntoView();
-    
+
     // Export button should exist
     cy.get('#export-history-btn').should('exist').and('be.visible');
     cy.get('#export-history-btn').should('contain', 'Export History');
-    
+
     // Import button should exist
     cy.get('#import-history-btn').should('exist').and('be.visible');
     cy.get('#import-history-btn').should('contain', 'Import History');
-    
+
     // File input for import should exist but be hidden
     cy.get('#import-history-file').should('exist');
   });
@@ -27,17 +27,17 @@ describe('History Export/Import', () => {
   it('should export empty history when no entries exist', () => {
     // Click export button
     cy.get('#export-history-btn').click();
-    
+
     // Check for success message
     cy.get('#import-status').should('have.class', 'status');
     cy.get('#import-status').should('contain', 'History exported successfully');
     cy.get('#import-status').should('contain', 'empty history');
-    
+
     // Verify download was triggered with correct content
     cy.window().then((win) => {
       expect(win.lastDownloadedFile).to.exist;
       expect(win.lastDownloadedFile.filename).to.match(/botc-history-\d{4}-\d{2}-\d{2}\.json/);
-      
+
       const content = JSON.parse(win.lastDownloadedFile.content);
       expect(content).to.deep.equal({
         version: 1,
@@ -57,7 +57,7 @@ describe('History Export/Import', () => {
       createdAt: Date.now() - 1000,
       updatedAt: Date.now() - 1000
     };
-    
+
     const grimoireEntry = {
       id: 'grimoire_test_1',
       name: 'Test Game',
@@ -69,16 +69,16 @@ describe('History Export/Import', () => {
       createdAt: Date.now(),
       updatedAt: Date.now()
     };
-    
+
     cy.window().then((win) => {
       win.localStorage.setItem('botcScriptHistoryV1', JSON.stringify([scriptEntry]));
       win.localStorage.setItem('botcGrimoireHistoryV1', JSON.stringify([grimoireEntry]));
     });
     cy.reload();
-    
+
     // Click export button
     cy.get('#export-history-btn').click();
-    
+
     // Verify download content
     cy.window().then((win) => {
       const content = JSON.parse(win.lastDownloadedFile.content);
@@ -115,18 +115,18 @@ describe('History Export/Import', () => {
         }
       ]
     };
-    
+
     // Mock file upload
     cy.get('#import-history-file').selectFile({
       contents: Cypress.Buffer.from(JSON.stringify(importData)),
       fileName: 'test-history.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Check for success message
     cy.get('#import-status').should('have.class', 'status');
     cy.get('#import-status').should('contain', 'History imported successfully');
-    
+
     // Verify history was imported
     cy.contains('#script-history-list .history-item .history-name', 'Imported Script').should('exist');
     cy.contains('#grimoire-history-list .history-item .history-name', 'Imported Game').should('exist');
@@ -141,12 +141,12 @@ describe('History Export/Import', () => {
       createdAt: Date.now() - 3000,
       updatedAt: Date.now() - 3000
     };
-    
+
     cy.window().then((win) => {
       win.localStorage.setItem('botcScriptHistoryV1', JSON.stringify([existingScript]));
     });
     cy.reload();
-    
+
     // Import new history
     const importData = {
       version: 1,
@@ -162,13 +162,13 @@ describe('History Export/Import', () => {
       ],
       grimoireHistory: []
     };
-    
+
     cy.get('#import-history-file').selectFile({
       contents: Cypress.Buffer.from(JSON.stringify(importData)),
       fileName: 'merge-test.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Both entries should exist
     cy.contains('#script-history-list .history-item .history-name', 'Existing Script').should('exist');
     cy.contains('#script-history-list .history-item .history-name', 'Another Import').should('exist');
@@ -183,12 +183,12 @@ describe('History Export/Import', () => {
       createdAt: Date.now() - 3000,
       updatedAt: Date.now() - 3000
     };
-    
+
     cy.window().then((win) => {
       win.localStorage.setItem('botcScriptHistoryV1', JSON.stringify([existingScript]));
     });
     cy.reload();
-    
+
     // Import with same ID but different content
     const importData = {
       version: 1,
@@ -204,17 +204,17 @@ describe('History Export/Import', () => {
       ],
       grimoireHistory: []
     };
-    
+
     cy.get('#import-history-file').selectFile({
       contents: Cypress.Buffer.from(JSON.stringify(importData)),
       fileName: 'duplicate-test.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Both entries should exist since they have different content
     cy.contains('#script-history-list .history-item .history-name', 'Original Entry').should('exist');
     cy.contains('#script-history-list .history-item .history-name', 'Different Content Entry').should('exist');
-    
+
     // Check that IDs are different
     cy.window().then((win) => {
       const history = JSON.parse(win.localStorage.getItem('botcScriptHistoryV1'));
@@ -230,7 +230,7 @@ describe('History Export/Import', () => {
       fileName: 'invalid.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Should show error alert
     cy.on('window:alert', (str) => {
       expect(str).to.match(/error.*import.*invalid/i);
@@ -242,13 +242,13 @@ describe('History Export/Import', () => {
     const invalidData = {
       someOtherField: 'not the right format'
     };
-    
+
     cy.get('#import-history-file').selectFile({
       contents: Cypress.Buffer.from(JSON.stringify(invalidData)),
       fileName: 'wrong-format.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Should show error alert
     cy.on('window:alert', (str) => {
       expect(str).to.match(/error.*import.*format/i);
@@ -259,15 +259,15 @@ describe('History Export/Import', () => {
     // Create initial history with specific timestamp to ensure consistency
     const createdAt = Date.now() - 10000;
     const updatedAt = Date.now() - 10000;
-    
+
     const scriptEntry = {
       id: 'script_no_dup_1',
       name: 'No Duplicate Script',
       data: [{ id: '_meta', name: 'No Duplicate Script', author: 'test' }, 'chef', 'librarian'],
-      createdAt: createdAt,
-      updatedAt: updatedAt
+      createdAt,
+      updatedAt
     };
-    
+
     const grimoireEntry = {
       id: 'grimoire_no_dup_1',
       name: 'No Duplicate Game',
@@ -276,37 +276,37 @@ describe('History Export/Import', () => {
       players: [
         { id: 'player_1', name: 'Alice', character: 'chef', isDead: false, isVoteless: false }
       ],
-      createdAt: createdAt,
-      updatedAt: updatedAt
+      createdAt,
+      updatedAt
     };
-    
+
     cy.window().then((win) => {
       win.localStorage.setItem('botcScriptHistoryV1', JSON.stringify([scriptEntry]));
       win.localStorage.setItem('botcGrimoireHistoryV1', JSON.stringify([grimoireEntry]));
     });
     cy.reload();
-    
+
     // Verify initial state
     cy.get('#script-history-list .history-item').should('have.length', 1);
     cy.get('#grimoire-history-list .history-item').should('have.length', 1);
-    
+
     // Export and then reimport the same data
     cy.get('#export-history-btn').click();
-    
+
     cy.window().then((win) => {
       const exportedData = win.lastDownloadedFile.content;
-      
+
       // Import the exported data back
       cy.get('#import-history-file').selectFile({
         contents: Cypress.Buffer.from(exportedData),
         fileName: 'reimport-test.json',
         mimeType: 'application/json'
       }, { force: true });
-      
+
       // Should still have only one entry each, not duplicates
       cy.get('#script-history-list .history-item').should('have.length', 1);
       cy.get('#grimoire-history-list .history-item').should('have.length', 1);
-      
+
       // Verify in localStorage too
       cy.window().then((win2) => {
         const scriptHistory = JSON.parse(win2.localStorage.getItem('botcScriptHistoryV1'));
@@ -351,13 +351,13 @@ describe('History Export/Import', () => {
         }
       ]
     };
-    
+
     cy.get('#import-history-file').selectFile({
       contents: Cypress.Buffer.from(JSON.stringify(importData)),
       fileName: 'count-test.json',
       mimeType: 'application/json'
     }, { force: true });
-    
+
     // Should show success with counts
     cy.get('#import-status').should('contain', '2 script');
     cy.get('#import-status').should('contain', '1 grimoire');
@@ -366,7 +366,7 @@ describe('History Export/Import', () => {
   it('should trigger file download with correct filename and content', () => {
     // This test verifies the actual download mechanism
     let downloadTriggered = false;
-    
+
     cy.window().then((win) => {
       // Override createElement to intercept download
       const originalCreateElement = win.document.createElement;
@@ -386,9 +386,9 @@ describe('History Export/Import', () => {
         return element;
       };
     });
-    
+
     cy.get('#export-history-btn').click();
-    
+
     cy.window().then(() => {
       expect(downloadTriggered).to.be.true;
     });

--- a/tests/23_death_vote.cy.js
+++ b/tests/23_death_vote.cy.js
@@ -25,10 +25,10 @@ describe('Death Vote Indicator', () => {
   it('shows alive count display even before game starts', () => {
     // Before starting game, setup info should exist
     cy.get('#setup-info').should('exist');
-    
+
     // Start game
     startGameWithPlayers(8);
-    
+
     // Now it should show 8/8 alive in setup info with script name
     cy.get('#setup-info').should('contain', 'Trouble Brewing');
     cy.get('#setup-info').should('contain', '8/8');
@@ -36,31 +36,31 @@ describe('Death Vote Indicator', () => {
 
   it('shows alive count in the grimoire center setup info', () => {
     startGameWithPlayers(8);
-    
+
     // Alive count should be in the setup info with script name and role counts
     cy.get('#setup-info').should('exist');
     cy.get('#setup-info').should('contain', 'Trouble Brewing');
     cy.get('#setup-info').should('contain', '8/8');
-    
+
     // Check that role counts have appropriate colors
     cy.get('#setup-info .townsfolk-count').should('exist').should('have.css', 'color', 'rgb(93, 173, 226)');
     cy.get('#setup-info .outsider-count').should('exist').should('have.css', 'color', 'rgb(189, 195, 199)');
     cy.get('#setup-info .minion-count').should('exist').should('have.css', 'color', 'rgb(243, 156, 18)');
     cy.get('#setup-info .demon-count').should('exist').should('have.css', 'color', 'rgb(231, 76, 60)');
-    
+
     // Mark first player as dead
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Alive count should update
     cy.get('#setup-info').should('contain', '7/8');
-    
+
     // Mark second player as dead
     cy.get('#player-circle li .player-token .death-ribbon').eq(1).within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Alive count should update again
     cy.get('#setup-info').should('contain', '6/8');
   });
@@ -72,7 +72,7 @@ describe('Death Vote Indicator', () => {
       cy.get('rect, path').first().click({ force: true });
     });
     cy.get('#player-circle li .player-token').first().should('have.class', 'is-dead');
-    
+
     // Death vote indicator should appear
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('exist');
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('be.visible');
@@ -80,138 +80,138 @@ describe('Death Vote Indicator', () => {
 
   it('removes death vote indicator when clicked (uses death vote)', () => {
     startGameWithPlayers(8);
-    
+
     // Mark first player as dead
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Death vote indicator should appear
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('exist');
-    
+
     // Click death vote indicator to use the vote
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').click({ force: true });
-    
+
     // Death vote indicator should disappear (vote used)
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('not.exist');
-    
+
     // Player should still be dead
     cy.get('#player-circle li .player-token').first().should('have.class', 'is-dead');
   });
 
   it('revives player when clicking death ribbon after death vote is used', () => {
     startGameWithPlayers(8);
-    
+
     // Mark first player as dead
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
     cy.get('#player-circle li .player-token').first().should('have.class', 'is-dead');
-    
+
     // Use death vote
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').click({ force: true });
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('not.exist');
-    
+
     // Click death ribbon again - should revive player
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Player should now be alive
     cy.get('#player-circle li .player-token').first().should('not.have.class', 'is-dead');
-    
+
     // Alive count should update
     cy.get('#setup-info').should('contain', '8/8');
   });
 
   it('persists death vote state across page reload', () => {
     startGameWithPlayers(8);
-    
+
     // Mark first player as dead
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Use death vote
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').click({ force: true });
-    
+
     // Reload page
     cy.reload();
-    
+
     // Player should still be dead
     cy.get('#player-circle li .player-token').first().should('have.class', 'is-dead');
-    
+
     // Death vote indicator should not be present (already used)
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('not.exist');
-    
+
     // Alive count should be correct
     cy.get('#setup-info').should('contain', '7/8');
   });
 
   it('resets death vote when player is marked alive without using vote', () => {
     startGameWithPlayers(8);
-    
+
     // Mark first player as dead
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Death vote indicator should appear
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('exist');
-    
+
     // Toggle back to alive without using death vote
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Player should be alive
     cy.get('#player-circle li .player-token').first().should('not.have.class', 'is-dead');
-    
+
     // Mark dead again
     cy.get('#player-circle li .player-token .death-ribbon').first().within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Death vote indicator should appear again (vote was reset)
     cy.get('#player-circle li .player-token').first().find('.death-vote-indicator').should('exist');
   });
 
   it('handles multiple dead players with independent death votes', () => {
     startGameWithPlayers(8);
-    
+
     // Mark first three players as dead
     for (let i = 0; i < 3; i++) {
       cy.get('#player-circle li .player-token .death-ribbon').eq(i).within(() => {
         cy.get('rect, path').first().click({ force: true });
       });
     }
-    
+
     // All three should have death vote indicators
     for (let i = 0; i < 3; i++) {
       cy.get('#player-circle li .player-token').eq(i).find('.death-vote-indicator').should('exist');
     }
-    
+
     // Alive count should show 5/8
     cy.get('#setup-info').should('contain', '5/8');
-    
+
     // Use death vote for player 1 only
     cy.get('#player-circle li .player-token').eq(0).find('.death-vote-indicator').click({ force: true });
-    
+
     // Player 1 should not have indicator, but players 2 and 3 should
     cy.get('#player-circle li .player-token').eq(0).find('.death-vote-indicator').should('not.exist');
     cy.get('#player-circle li .player-token').eq(1).find('.death-vote-indicator').should('exist');
     cy.get('#player-circle li .player-token').eq(2).find('.death-vote-indicator').should('exist');
-    
+
     // Revive player 1 using death ribbon
     cy.get('#player-circle li .player-token .death-ribbon').eq(0).within(() => {
       cy.get('rect, path').first().click({ force: true });
     });
-    
+
     // Player 1 should be alive, others still dead
     cy.get('#player-circle li .player-token').eq(0).should('not.have.class', 'is-dead');
     cy.get('#player-circle li .player-token').eq(1).should('have.class', 'is-dead');
     cy.get('#player-circle li .player-token').eq(2).should('have.class', 'is-dead');
-    
+
     // Alive count should update to 6/8
     cy.get('#setup-info').should('contain', '6/8');
   });

--- a/tests/24_history_file_validation.cy.js
+++ b/tests/24_history_file_validation.cy.js
@@ -49,7 +49,7 @@ describe('History File Validation', () => {
 
     // The character sheet should not be updated
     cy.get('#character-sheet').should('contain', 'Load a script to see available characters');
-    
+
     // Load status should show error
     cy.get('#load-status').should('have.class', 'error');
     cy.get('#load-status').should('contain', 'history');

--- a/tests/25_bluff_tokens.cy.js
+++ b/tests/25_bluff_tokens.cy.js
@@ -12,15 +12,15 @@ describe('Bluff Tokens', () => {
   it('should display three empty bluff token slots at bottom left', () => {
     // Check that bluff tokens container exists
     cy.get('#bluff-tokens-container').should('be.visible');
-    
+
     // Verify it's positioned at bottom left
     cy.get('#bluff-tokens-container').should('have.css', 'position', 'absolute');
     cy.get('#bluff-tokens-container').should('have.css', 'bottom');
     cy.get('#bluff-tokens-container').should('have.css', 'left');
-    
+
     // Check for exactly 3 bluff token slots
     cy.get('#bluff-tokens-container .bluff-token').should('have.length', 3);
-    
+
     // Each bluff token should have empty appearance initially
     cy.get('#bluff-tokens-container .bluff-token').each(($token) => {
       cy.wrap($token).should('have.class', 'empty');
@@ -31,13 +31,13 @@ describe('Bluff Tokens', () => {
   it('should open character selection modal when clicking a bluff token', () => {
     // Click the first bluff token
     cy.get('#bluff-tokens-container .bluff-token').first().click();
-    
+
     // Verify character modal opens
     cy.get('#character-modal').should('be.visible');
-    
+
     // Verify modal title indicates it's for bluff selection
     cy.get('#character-modal h3').should('contain', 'Select Bluff');
-    
+
     // Character grid should be populated
     cy.get('#character-grid .token').should('have.length.greaterThan', 0);
   });
@@ -45,19 +45,19 @@ describe('Bluff Tokens', () => {
   it('should assign a character to bluff token when selected', () => {
     // Click first bluff token
     cy.get('#bluff-tokens-container .bluff-token').first().click();
-    
+
     // Select a specific character (e.g., Baron)
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify modal closes
     cy.get('#character-modal').should('not.be.visible');
-    
+
     // Verify bluff token now shows the selected character
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('not.have.class', 'empty')
       .should('have.class', 'has-character');
-    
+
     // Check that the Baron's image is displayed
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.attr', 'data-character', 'baron');
@@ -68,18 +68,18 @@ describe('Bluff Tokens', () => {
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify character is assigned
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.class', 'has-character');
-    
+
     // Click the bluff token again to change it
     cy.get('#bluff-tokens-container .bluff-token').first().click();
-    
+
     // Select "None" option
     cy.get('#character-search').clear().type('none');
     cy.get('#character-grid .token.empty').click();
-    
+
     // Verify bluff token is cleared
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.class', 'empty')
@@ -89,17 +89,17 @@ describe('Bluff Tokens', () => {
   it('should maintain independent state for each bluff token', () => {
     // Assign different characters to each bluff token
     const characters = ['baron', 'poisoner', 'spy'];
-    
+
     characters.forEach((character, index) => {
       cy.get('#bluff-tokens-container .bluff-token').eq(index).click();
       cy.get('#character-search').clear().type(character);
       cy.get('#character-grid .token').first().click();
-      
+
       // Verify assignment
       cy.get('#bluff-tokens-container .bluff-token').eq(index)
         .should('have.attr', 'data-character', character);
     });
-    
+
     // Verify all three have different characters
     cy.get('#bluff-tokens-container .bluff-token[data-character="baron"]').should('exist');
     cy.get('#bluff-tokens-container .bluff-token[data-character="poisoner"]').should('exist');
@@ -111,10 +111,10 @@ describe('Bluff Tokens', () => {
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Hover over the bluff token
     cy.get('#bluff-tokens-container .bluff-token').first().trigger('mouseenter');
-    
+
     // Check for tooltip
     cy.get('#ability-tooltip').should('be.visible');
     cy.get('#ability-tooltip').should('contain', 'Baron');
@@ -123,19 +123,19 @@ describe('Bluff Tokens', () => {
   it('should persist bluff tokens when saving and loading grimoire state', () => {
     // Assign characters to bluff tokens
     const characters = ['baron', 'poisoner', 'spy'];
-    
+
     characters.forEach((character, index) => {
       cy.get('#bluff-tokens-container .bluff-token').eq(index).click();
       cy.get('#character-search').clear().type(character);
       cy.get('#character-grid .token').first().click();
     });
-    
+
     // Reload the page (state should be auto-saved)
     cy.reload();
-    
+
     // Wait for grimoire to load
     cy.get('#player-circle', { timeout: 10000 }).should('be.visible');
-    
+
     // Verify bluff tokens are restored
     characters.forEach((character, index) => {
       cy.get('#bluff-tokens-container .bluff-token').eq(index)
@@ -148,11 +148,11 @@ describe('Bluff Tokens', () => {
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Start a new game - sidebar should already be visible
     cy.get('#player-count').clear().type('12');
     cy.get('#start-game').click();
-    
+
     // Verify bluff tokens are reset
     cy.get('#bluff-tokens-container .bluff-token').each(($token) => {
       cy.wrap($token).should('have.class', 'empty');
@@ -163,17 +163,17 @@ describe('Bluff Tokens', () => {
   it('should handle touch interactions on mobile', () => {
     // Set mobile viewport
     cy.viewport('iphone-x');
-    
+
     // On mobile, the regular click should still work due to our touch handler
     cy.get('#bluff-tokens-container .bluff-token').first().click({ force: true });
-    
+
     // Verify character modal opens
     cy.get('#character-modal').should('be.visible');
-    
+
     // Select a character
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify assignment works on mobile
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.attr', 'data-character', 'baron');
@@ -183,15 +183,15 @@ describe('Bluff Tokens', () => {
     // Check that bluff tokens have specific styling
     cy.get('#bluff-tokens-container .bluff-token').first().then($token => {
       const styles = window.getComputedStyle($token[0]);
-      
+
       // Should have a different border or indicator to distinguish from player tokens
       expect(styles.borderStyle).to.not.equal('none');
-      
+
       // Should be smaller than player tokens - get player token for comparison
-      const bluffSize = parseInt(styles.width);
-      
+      const bluffSize = parseInt(styles.width, 10);
+
       cy.get('.player-token').first().then($playerToken => {
-        const playerSize = parseInt(window.getComputedStyle($playerToken[0]).width);
+        const playerSize = parseInt(window.getComputedStyle($playerToken[0]).width, 10);
         expect(bluffSize).to.be.lessThan(playerSize);
       });
     });
@@ -202,17 +202,17 @@ describe('Bluff Tokens', () => {
     cy.get('#player-circle li').first().find('.player-token').click();
     cy.get('#character-search').type('washerwoman');
     cy.get('#character-grid .token').first().click();
-    
+
     // Assign a character to a bluff token
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify both assignments are independent
     cy.get('#player-circle li').first().find('.player-token')
       .should('have.css', 'background-image')
       .and('include', 'washerwoman');
-    
+
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.attr', 'data-character', 'baron');
   });
@@ -221,14 +221,14 @@ describe('Bluff Tokens', () => {
     // Load a different script - sidebar should already be visible from beforeEach
     cy.get('#load-bmr').click();
     cy.get('#load-status', { timeout: 10000 }).should('contain', 'successfully');
-    
+
     // Close sidebar to interact with bluff tokens
     cy.get('#sidebar-close').click();
-    
+
     // Verify bluff tokens still work
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-modal').should('be.visible');
-    
+
     // Character grid should show Bad Moon Rising characters
     cy.get('#character-search').type('zombuul');
     cy.get('#character-grid .token').should('have.length.greaterThan', 0);

--- a/tests/26_bluff_token_player_interaction_bug.cy.js
+++ b/tests/26_bluff_token_player_interaction_bug.cy.js
@@ -15,28 +15,28 @@ describe('Bluff Token Player Interaction Bug', () => {
     cy.get('#character-modal').should('be.visible');
     cy.get('#character-search').type('washerwoman');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify character was assigned
     cy.get('#player-circle li').first().find('.player-token')
       .should('have.css', 'background-image')
       .and('include', 'washerwoman');
-    
+
     // Now assign a bluff token
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-modal').should('be.visible');
     cy.get('#character-search').type('baron');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify bluff was assigned
     cy.get('#bluff-tokens-container .bluff-token').first()
       .should('have.attr', 'data-character', 'baron');
-    
+
     // Now try to click on another player token - this should work
     cy.get('#player-circle li').eq(1).find('.player-token').click();
     cy.get('#character-modal').should('be.visible');
     cy.get('#character-search').type('virgin');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify second player character was assigned
     cy.get('#player-circle li').eq(1).find('.player-token')
       .should('have.css', 'background-image')
@@ -49,13 +49,13 @@ describe('Bluff Token Player Interaction Bug', () => {
     cy.get('#character-modal').should('be.visible');
     cy.get('#close-character-modal').click();
     cy.get('#character-modal').should('not.be.visible');
-    
+
     // Now player tokens should still work
     cy.get('#player-circle li').first().find('.player-token').click();
     cy.get('#character-modal').should('be.visible');
     cy.get('#character-search').type('washerwoman');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify character was assigned
     cy.get('#player-circle li').first().find('.player-token')
       .should('have.css', 'background-image')
@@ -66,17 +66,17 @@ describe('Bluff Token Player Interaction Bug', () => {
     // Open bluff modal and then close it by clicking outside
     cy.get('#bluff-tokens-container .bluff-token').first().click();
     cy.get('#character-modal').should('be.visible');
-    
+
     // Click outside the modal (on the backdrop)
     cy.get('#character-modal').click('topLeft');
     cy.get('#character-modal').should('not.be.visible');
-    
+
     // Now player tokens should still work
     cy.get('#player-circle li').first().find('.player-token').click();
     cy.get('#character-modal').should('be.visible');
     cy.get('#character-search').type('washerwoman');
     cy.get('#character-grid .token').first().click();
-    
+
     // Verify character was assigned
     cy.get('#player-circle li').first().find('.player-token')
       .should('have.css', 'background-image')


### PR DESCRIPTION
Fixes long-press context menus disappearing on touch release and resolves various ESLint issues.

The long-press timer was being unconditionally cleared by `pointerup`, `pointercancel`, `pointerleave`, `touchend`, and `touchcancel` events, causing context menus to vanish immediately after appearing on touch devices like Safari iPhone. The fix adds a check to ensure the timer is only cleared if the menu is not already visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-74d67d18-d40e-48ba-bb77-42cc2d7deff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74d67d18-d40e-48ba-bb77-42cc2d7deff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

