### PR TITLE
feat: add storyteller/player mode toggle and player mode

### DIFF
--- a/.cursor/rules
+++ b/.cursor/rules
@@ -34,3 +34,7 @@ steps:
   - id: require_green_tests
     when: pre-commit
     run: echo "Require: Do not commit/push if tests fail. Fix and re-run until green."
+
+  - id: static_imports_only
+    when: always
+    run: echo "Code style: Use only top-level static imports. No dynamic require/import()."

--- a/.cursor/rules
+++ b/.cursor/rules
@@ -26,3 +26,11 @@ steps:
   - id: commit_message_guideline
     when: pre-commit
     run: echo "Commits: Use Conventional Commits with subject < 80 chars."
+
+  - id: run_tests_pre_push
+    when: pre-push
+    run: npx --yes http-server -p {{test_port}} -c- . > /dev/null 2>&1 & CYPRESS_BASE_URL=http://127.0.0.1:{{test_port}} npx --yes cypress run --config-file tests/cypress.config.js ; kill %1 || true
+
+  - id: require_green_tests
+    when: pre-commit
+    run: echo "Require: Do not commit/push if tests fail. Fix and re-run until green."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,9 @@ npx eslint --fix
 
 - Use Conventional Commits (e.g., `feat:`, `fix:`, `docs:`, `refactor:`).
 - Keep the subject line strictly under 80 characters.
+
+5. Require Green Tests Before Commit/Push
+
+- Always run the full Cypress suite before committing or pushing.
+- If any tests fail, fix the code or tests, then re-run until all pass.
+- Do not commit/push with failing tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,3 +36,8 @@ npx eslint --fix
 - Always run the full Cypress suite before committing or pushing.
 - If any tests fail, fix the code or tests, then re-run until all pass.
 - Do not commit/push with failing tests.
+
+6. Static Imports Only
+
+- Do not use dynamic `require`/`import()` within functions or blocks.
+- Always place all imports at the top of the module.

--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
           <label for="player-count">Player Count:</label>
           <input type="number" id="player-count" min="5" max="20">
         </div>
+        <div id="mode-toggle" style="margin-top: 8px; display: flex; gap: 10px; align-items: center;">
+          <span>Mode:</span>
+          <label><input type="radio" name="mode" id="mode-storyteller" value="storyteller" checked> Storyteller</label>
+          <label><input type="radio" name="mode" id="mode-player" value="player"> Player</label>
+        </div>
         <button class="button" id="start-game">Start Game</button>
         <div id="game-status" class="status" aria-live="polite"></div>
       </div>

--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ import { initInAppTour } from './src/ui/tour.js';
 import { populateReminderTokenGrid } from './src/reminder.js';
 import { initDayNightTracking, generateReminderId, addReminderTimestamp } from './src/dayNightTracking.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const startGameBtn = document.getElementById('start-game');
   const loadTbBtn = document.getElementById('load-tb');
   const loadBmrBtn = document.getElementById('load-bmr');
@@ -382,9 +382,8 @@ document.addEventListener('DOMContentLoaded', () => {
   initExportImport();
 
   // Restore previous session (script and grimoire)
-  loadAppState({ grimoireState, grimoireHistoryList }).then(() => {
-    applyModeUI();
-  });
+  await loadAppState({ grimoireState, grimoireHistoryList });
+  applyModeUI();
 
   // Initialize day/night tracking
   initDayNightTracking(grimoireState);

--- a/script.js
+++ b/script.js
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const val = e && e.target && e.target.value;
       grimoireState.mode = (val === 'player') ? 'player' : 'storyteller';
       applyModeUI();
-      try { localStorage.setItem(MODE_STORAGE_KEY, grimoireState.mode); } catch (_) {}
+      try { localStorage.setItem(MODE_STORAGE_KEY, grimoireState.mode); } catch (_) { }
       saveAppState({ grimoireState });
     };
     modeStorytellerRadio.addEventListener('change', onModeChange);
@@ -152,7 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
       grimoireState.nightOrderSort = nightOrderSortCheckbox.checked;
       try {
         localStorage.setItem('nightOrderSort', grimoireState.nightOrderSort ? '1' : '0');
-      } catch (_) {}
+      } catch (_) { }
 
       if (nightOrderControls) {
         nightOrderControls.classList.toggle('active', grimoireState.nightOrderSort);
@@ -175,7 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
       grimoireState.nightPhase = e.target.value;
       try {
         localStorage.setItem('nightPhase', grimoireState.nightPhase);
-      } catch (_) {}
+      } catch (_) { }
 
       // Re-display the script with new phase
       if (grimoireState.scriptData && grimoireState.nightOrderSort) {

--- a/script.js
+++ b/script.js
@@ -104,10 +104,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
     const isPlayer = grimoireState.mode === 'player';
     if (dayNightToggleBtn) dayNightToggleBtn.style.display = isPlayer ? 'none' : '';
-    if (dayNightSlider) {
-      if (isPlayer) {
-        dayNightSlider.style.display = 'none';
-      }
+    if (dayNightSlider && isPlayer) {
+      dayNightSlider.classList.remove('open');
+      dayNightSlider.style.display = 'none';
+    }
+    if (isPlayer && grimoireState.dayNightTracking) {
+      grimoireState.dayNightTracking.enabled = false;
     }
   };
 

--- a/script.js
+++ b/script.js
@@ -12,9 +12,9 @@ import { displayScript, loadScriptFile, loadScriptFromFile } from './src/script.
 import { initSidebarResize, initSidebarToggle } from './src/ui/sidebar.js';
 import { initInAppTour } from './src/ui/tour.js';
 import { populateReminderTokenGrid } from './src/reminder.js';
-import { initDayNightTracking, generateReminderId, addReminderTimestamp, updateDayNightUI } from './src/dayNightTracking.js';
+import { initDayNightTracking, generateReminderId, addReminderTimestamp } from './src/dayNightTracking.js';
 
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', () => {
   const startGameBtn = document.getElementById('start-game');
   const loadTbBtn = document.getElementById('load-tb');
   const loadBmrBtn = document.getElementById('load-bmr');
@@ -108,6 +108,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       dayNightSlider.classList.remove('open');
       dayNightSlider.style.display = 'none';
     }
+    if (isPlayer && grimoireState.dayNightTracking) {
+      grimoireState.dayNightTracking.enabled = false;
+    }
   };
 
   if (modeStorytellerRadio && modePlayerRadio) {
@@ -116,11 +119,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       const val = e && e.target && e.target.value;
       grimoireState.mode = (val === 'player') ? 'player' : 'storyteller';
       applyModeUI();
-      // If switching to player mode, disable day/night tracking statefully
-      if (grimoireState.mode === 'player' && grimoireState.dayNightTracking && grimoireState.dayNightTracking.enabled) {
-        grimoireState.dayNightTracking.enabled = false;
-        updateDayNightUI(grimoireState);
-      }
       try { localStorage.setItem(MODE_STORAGE_KEY, grimoireState.mode); } catch (_) { }
       saveAppState({ grimoireState });
     };
@@ -384,8 +382,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   initExportImport();
 
   // Restore previous session (script and grimoire)
-  await loadAppState({ grimoireState, grimoireHistoryList });
-  applyModeUI();
+  loadAppState({ grimoireState, grimoireHistoryList }).then(() => {
+    applyModeUI();
+  });
 
   // Initialize day/night tracking
   initDayNightTracking(grimoireState);

--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ import { initInAppTour } from './src/ui/tour.js';
 import { populateReminderTokenGrid } from './src/reminder.js';
 import { initDayNightTracking, generateReminderId, addReminderTimestamp } from './src/dayNightTracking.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const startGameBtn = document.getElementById('start-game');
   const loadTbBtn = document.getElementById('load-tb');
   const loadBmrBtn = document.getElementById('load-bmr');
@@ -381,13 +381,12 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize export/import functionality
   initExportImport();
 
-  // Restore previous session (script and grimoire)
-  loadAppState({ grimoireState, grimoireHistoryList }).then(() => {
-    applyModeUI();
-  });
-
-  // Initialize day/night tracking
+  // Initialize day/night tracking first
   initDayNightTracking(grimoireState);
+
+  // Restore previous session (script and grimoire), then apply mode UI
+  await loadAppState({ grimoireState, grimoireHistoryList });
+  applyModeUI();
 
   // In-app tour
   initInAppTour();

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ import { displayScript, loadScriptFile, loadScriptFromFile } from './src/script.
 import { initSidebarResize, initSidebarToggle } from './src/ui/sidebar.js';
 import { initInAppTour } from './src/ui/tour.js';
 import { populateReminderTokenGrid } from './src/reminder.js';
-import { initDayNightTracking, generateReminderId, addReminderTimestamp } from './src/dayNightTracking.js';
+import { initDayNightTracking, generateReminderId, addReminderTimestamp, updateDayNightUI } from './src/dayNightTracking.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const startGameBtn = document.getElementById('start-game');
@@ -108,9 +108,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       dayNightSlider.classList.remove('open');
       dayNightSlider.style.display = 'none';
     }
-    if (isPlayer && grimoireState.dayNightTracking) {
-      grimoireState.dayNightTracking.enabled = false;
-    }
   };
 
   if (modeStorytellerRadio && modePlayerRadio) {
@@ -119,6 +116,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       const val = e && e.target && e.target.value;
       grimoireState.mode = (val === 'player') ? 'player' : 'storyteller';
       applyModeUI();
+      // If switching to player mode, disable day/night tracking statefully
+      if (grimoireState.mode === 'player' && grimoireState.dayNightTracking && grimoireState.dayNightTracking.enabled) {
+        grimoireState.dayNightTracking.enabled = false;
+        updateDayNightUI(grimoireState);
+      }
       try { localStorage.setItem(MODE_STORAGE_KEY, grimoireState.mode); } catch (_) { }
       saveAppState({ grimoireState });
     };

--- a/src/app.js
+++ b/src/app.js
@@ -45,6 +45,8 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     }
     if (saved && saved.bluffs) {
       grimoireState.bluffs = saved.bluffs;
+      // Ensure bluff tokens reflect restored state
+      updateGrimoire({ grimoireState });
     }
     if (saved && saved.mode) {
       grimoireState.mode = saved.mode === 'player' ? 'player' : 'storyteller';

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import { INCLUDE_TRAVELLERS_KEY } from './constants.js';
+import { INCLUDE_TRAVELLERS_KEY, MODE_STORAGE_KEY } from './constants.js';
 import { renderSetupInfo, setupGrimoire, updateGrimoire } from './grimoire.js';
 import { repositionPlayers } from './ui/layout.js';
 import { processScriptData } from './script.js';
@@ -11,10 +11,12 @@ export function saveAppState({ grimoireState }) {
       players: grimoireState.players,
       scriptName: grimoireState.scriptMetaName,
       dayNightTracking: grimoireState.dayNightTracking,
-      bluffs: grimoireState.bluffs || [null, null, null]
+      bluffs: grimoireState.bluffs || [null, null, null],
+      mode: grimoireState.mode || 'storyteller'
     };
     localStorage.setItem('botcAppStateV1', JSON.stringify(state));
     try { localStorage.setItem(INCLUDE_TRAVELLERS_KEY, grimoireState.includeTravellers ? '1' : '0'); } catch (_) { }
+    try { localStorage.setItem(MODE_STORAGE_KEY, (grimoireState.mode === 'player') ? 'player' : 'storyteller'); } catch (_) { }
   } catch (_) { }
 }
 
@@ -43,6 +45,9 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     }
     if (saved && saved.bluffs) {
       grimoireState.bluffs = saved.bluffs;
+    }
+    if (saved && saved.mode) {
+      grimoireState.mode = saved.mode === 'player' ? 'player' : 'storyteller';
     }
   } catch (_) { } finally { grimoireState.isRestoringState = false; }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -45,8 +45,6 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     }
     if (saved && saved.bluffs) {
       grimoireState.bluffs = saved.bluffs;
-      // Ensure bluff tokens reflect restored state
-      updateGrimoire({ grimoireState });
     }
     if (saved && saved.mode) {
       grimoireState.mode = saved.mode === 'player' ? 'player' : 'storyteller';

--- a/src/constants.js
+++ b/src/constants.js
@@ -10,3 +10,4 @@ export const prefersOverlaySidebar = window.matchMedia('(max-width: 900px)');
 export const INCLUDE_TRAVELLERS_KEY = 'botcIncludeTravellersV1';
 export const BG_STORAGE_KEY = 'grimoireBackgroundV1';
 export const minReminderSize = 28;
+export const MODE_STORAGE_KEY = 'botcModeV1';

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,9 +2,9 @@ export const TOUCH_EXPAND_SUPPRESS_MS = 350;
 export const CLICK_EXPAND_SUPPRESS_MS = 250;
 // Dynamic touch detection to support testing
 export const isTouchDevice = () => {
-  return (window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches) || 
-         ('ontouchstart' in window) || 
-         (navigator.maxTouchPoints > 0);
+  return (window.matchMedia && window.matchMedia('(hover: none) and (pointer: coarse)').matches) ||
+    ('ontouchstart' in window) ||
+    (navigator.maxTouchPoints > 0);
 };
 export const prefersOverlaySidebar = window.matchMedia('(max-width: 900px)');
 export const INCLUDE_TRAVELLERS_KEY = 'botcIncludeTravellersV1';

--- a/tests/27_storyteller_player_mode.cy.js
+++ b/tests/27_storyteller_player_mode.cy.js
@@ -92,6 +92,26 @@ describe('Storyteller / Player Mode', () => {
     cy.get('#reminder-token-modal').should('not.be.visible');
     cy.get('#player-circle li').first().find('.icon-reminder').should('have.length.greaterThan', 0);
   });
+
+  it('collapses night slider and disables tracking when switching to player', () => {
+    // Ensure slider is closed initially
+    cy.get('#day-night-slider').should('not.be.visible');
+
+    // Enable tracking (storyteller mode)
+    cy.get('#day-night-toggle').should('be.visible').click();
+    cy.get('#day-night-slider').should('be.visible');
+    cy.get('#day-night-slider').should('have.class', 'open');
+
+    // Switch to player mode
+    cy.get('#mode-player').click({ force: true });
+
+    // Slider should be collapsed/hidden and tracking disabled
+    cy.get('#day-night-slider').should('not.be.visible');
+    cy.get('#day-night-slider').should('not.have.class', 'open');
+    cy.window().then((win) => {
+      expect(win.grimoireState.dayNightTracking.enabled).to.eq(false);
+    });
+  });
 });
 
 

--- a/tests/27_storyteller_player_mode.cy.js
+++ b/tests/27_storyteller_player_mode.cy.js
@@ -1,0 +1,97 @@
+// Cypress E2E tests - Storyteller/Player mode toggle and behaviors (TDD-first)
+
+const startGameWithPlayers = (n) => {
+  cy.get('#player-count').then(($el) => {
+    const el = $el[0];
+    el.value = String(n);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  cy.get('#start-game').click();
+  cy.get('#player-circle li').should('have.length', n);
+};
+
+describe('Storyteller / Player Mode', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.viewport(1280, 900);
+    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) {} });
+    // Load Trouble Brewing for deterministic reminders/characters
+    cy.get('#load-tb').click();
+    cy.get('#character-sheet .role').should('have.length.greaterThan', 5);
+    startGameWithPlayers(5);
+  });
+
+  it('shows mode toggle and hides day/night toggle in player mode', () => {
+    // Toggle inputs next to player count
+    cy.get('#mode-storyteller').should('exist').and('be.checked');
+    cy.get('#mode-player').should('exist').and('not.be.checked');
+
+    // Day/Night toggle visible by default in storyteller mode
+    cy.get('#day-night-toggle').should('be.visible');
+
+    // Switch to player mode and ensure day/night toggle is hidden
+    cy.get('#mode-player').click({ force: true });
+    cy.get('#mode-player').should('be.checked');
+    cy.get('#mode-storyteller').should('not.be.checked');
+    cy.get('#day-night-toggle').should('not.be.visible');
+
+    // Switch back to storyteller mode and ensure visibility returns
+    cy.get('#mode-storyteller').click({ force: true });
+    cy.get('#day-night-toggle').should('be.visible');
+  });
+
+  it('storyteller shows character-specific reminders; player hides them', () => {
+    // Open reminder token modal in storyteller mode
+    cy.get('#player-circle li .reminder-placeholder').first().click({ force: true });
+    cy.get('#reminder-token-modal').should('be.visible');
+
+    // Librarian has a character-specific reminder "Outsider" in TB
+    cy.get('#reminder-token-grid .token[title="Outsider"]').should('have.length.greaterThan', 0);
+
+    // Close modal
+    cy.get('#reminder-token-modal').click('topLeft', { force: true });
+    cy.get('#reminder-token-modal').should('not.be.visible');
+
+    // Switch to player mode
+    cy.get('#mode-player').click({ force: true });
+
+    // Open modal again
+    cy.get('#player-circle li .reminder-placeholder').first().click({ force: true });
+    cy.get('#reminder-token-modal').should('be.visible');
+
+    // Character-specific reminder tokens should be hidden in player mode
+    cy.get('#reminder-token-grid .token[title="Outsider"]').should('have.length', 0);
+
+    // Close
+    cy.get('#reminder-token-modal').click('topLeft', { force: true });
+    cy.get('#reminder-token-modal').should('not.be.visible');
+  });
+
+  it('player mode shows character tokens (by name) in reminder selection', () => {
+    // Ensure storyteller mode does not show character tokens by name
+    cy.get('#player-circle li .reminder-placeholder').first().click({ force: true });
+    cy.get('#reminder-token-modal').should('be.visible');
+    cy.get('#reminder-token-search').clear().type('washerwoman');
+    cy.get('#reminder-token-grid .token[title="Washerwoman"]').should('have.length', 0);
+    cy.get('#reminder-token-modal').click('topLeft', { force: true });
+
+    // Switch to player mode
+    cy.get('#mode-player').click({ force: true });
+
+    // Open modal and search for a TB character
+    cy.get('#player-circle li .reminder-placeholder').first().click({ force: true });
+    cy.get('#reminder-token-modal').should('be.visible');
+    cy.get('#reminder-token-search').clear().type('washerwoman');
+
+    // In player mode, there should be a token labeled with the character's name
+    cy.get('#reminder-token-grid .token[title="Washerwoman"]').should('have.length.greaterThan', 0);
+
+    // Selecting it should add an icon reminder to the player
+    cy.get('#reminder-token-grid .token[title="Washerwoman"]').first().click({ force: true });
+    cy.get('#reminder-token-modal').should('not.be.visible');
+    cy.get('#player-circle li').first().find('.icon-reminder').should('have.length.greaterThan', 0);
+  });
+});
+
+

--- a/tests/27_storyteller_player_mode.cy.js
+++ b/tests/27_storyteller_player_mode.cy.js
@@ -15,7 +15,7 @@ describe('Storyteller / Player Mode', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.viewport(1280, 900);
-    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) {} });
+    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) { } });
     // Load Trouble Brewing for deterministic reminders/characters
     cy.get('#load-tb').click();
     cy.get('#character-sheet .role').should('have.length.greaterThan', 5);


### PR DESCRIPTION
Adds storyteller/player mode toggle near player count. In player mode, hides day/night toggle and replaces character-specific reminder tokens with character tokens (named). Persists mode in localStorage and app state. Includes Cypress tests following TDD-first.