### PR TITLE
Replace background images with solid colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,9 +89,12 @@
         <div>
           <select id="background-select">
             <option value="none">No background</option>
-            <option value="background4-C7TzDZ7M.webp">Default Background</option>
-            <option value="background4-X8jQb4tv.webp">Background 1</option>
-            <option value="background-bJ1INm6Z.webp">Background 2</option>
+            <option value="red">Red</option>
+            <option value="blue">Blue</option>
+            <option value="purple">Purple</option>
+            <option value="green">Green</option>
+            <option value="orange">Orange</option>
+            <option value="dark">Dark</option>
           </select>
         </div>
       </div>

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -1483,11 +1483,21 @@ export function applyGrimoireBackground(value) {
   if (!centerEl) return;
   if (!value || value === 'none') {
     centerEl.style.backgroundImage = 'none';
+    centerEl.style.backgroundColor = 'transparent';
   } else {
-    const url = `./assets/img/${value}`;
-    centerEl.style.backgroundImage = `url('${url}')`;
-    centerEl.style.backgroundSize = 'cover';
-    centerEl.style.backgroundPosition = 'center';
+    // Map color names to actual color values
+    const colorMap = {
+      'red': '#ff4444',
+      'blue': '#4444ff',
+      'purple': '#8844ff',
+      'green': '#44ff44',
+      'orange': '#ff8844',
+      'dark': '#222222'
+    };
+    
+    const color = colorMap[value] || value; // Use mapped color or the value itself if it's already a hex color
+    centerEl.style.backgroundImage = 'none';
+    centerEl.style.backgroundColor = color;
   }
 }
 
@@ -1496,7 +1506,7 @@ export function initGrimoireBackground() {
   const backgroundSelect = document.getElementById('background-select');
   if (!centerEl) return;
   try {
-    const savedBg = localStorage.getItem(BG_STORAGE_KEY) || 'background4-C7TzDZ7M.webp';
+    const savedBg = localStorage.getItem(BG_STORAGE_KEY) || 'blue';
     applyGrimoireBackground(savedBg);
     if (backgroundSelect) backgroundSelect.value = savedBg === 'none' ? 'none' : savedBg;
   } catch (_) { }

--- a/tests/05_upload_and_background.cy.js
+++ b/tests/05_upload_and_background.cy.js
@@ -56,21 +56,21 @@ describe('Upload & Background', () => {
   });
 
   it('background selection applies and persists across reloads', () => {
-    // Choose Background 1
-    cy.get('#background-select').select('Background 1');
+    // Choose Blue background
+    cy.get('#background-select').select('blue');
     // Style applied
     cy.get('#center')
       .should(($el) => {
-        const bg = getComputedStyle($el[0]).backgroundImage;
-        expect(bg).to.contain('background4-X8jQb4tv.webp');
+        const bg = getComputedStyle($el[0]).backgroundColor;
+        expect(bg).to.contain('rgb(68, 68, 255)'); // #4444ff in rgb
       });
     // Persist in storage and reload
     cy.reload();
-    cy.get('#background-select').should('have.value', 'background4-X8jQb4tv.webp');
+    cy.get('#background-select').should('have.value', 'blue');
     cy.get('#center')
       .should(($el) => {
-        const bg = getComputedStyle($el[0]).backgroundImage;
-        expect(bg).to.contain('background4-X8jQb4tv.webp');
+        const bg = getComputedStyle($el[0]).backgroundColor;
+        expect(bg).to.contain('rgb(68, 68, 255)'); // #4444ff in rgb
       });
   });
 });


### PR DESCRIPTION
Remove background images and replace them with solid color options, updating the background selection dropdown accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-85b2b35c-640f-4a81-928a-6cc95dc5a43c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85b2b35c-640f-4a81-928a-6cc95dc5a43c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

