### PR TITLE
style: remove death UI from grimoire hidden state

### DIFF
--- a/styles/core.css
+++ b/styles/core.css
@@ -114,12 +114,6 @@ body.grimoire-hidden #bluff-tokens-container {
   display: none !important;
 }
 
-/* Also hide death UI while hidden */
-body.grimoire-hidden #player-circle li .player-token .death-ribbon,
-body.grimoire-hidden #player-circle li .player-token .death-vote-indicator {
-  display: none !important;
-}
-
 /* During number selection, hide reminders, bluffs, and death UI like hidden mode */
 body.selection-active #player-circle li .reminders,
 body.selection-active #player-circle li .reminder-placeholder,


### PR DESCRIPTION
Fixes #258

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes CSS that hid `death-ribbon` and `death-vote-indicator` in `grimoire-hidden`, keeping them visible (still hidden during `selection-active`).
> 
> - **CSS (styles/core.css)**:
>   - Remove `body.grimoire-hidden` rules that hid `#player-circle li .player-token .death-ribbon` and `.death-vote-indicator`.
>   - Death UI remains visible in hidden mode; still suppressed under `body.selection-active`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 013aafc296c1bdc95ee3c88f311e92c7285e1391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->