### PR TITLE
fix: day/night tracking

### DIFF
--- a/src/dayNightTracking.js
+++ b/src/dayNightTracking.js
@@ -181,11 +181,6 @@ export function addReminderTimestamp(grimoireState, reminderId) {
   }
 }
 
-export function getReminderTimestamp(grimoireState, reminderId) {
-  if (!grimoireState.dayNightTracking.enabled) return null;
-  return grimoireState.dayNightTracking.reminderTimestamps[reminderId] || null;
-}
-
 export function isReminderVisible(grimoireState, reminderId) {
   if (!grimoireState.dayNightTracking.enabled) return true;
 

--- a/src/reminder.js
+++ b/src/reminder.js
@@ -1,6 +1,6 @@
 import { resolveAssetPath } from '../utils.js';
 import { withStateSave } from './app.js';
-import { addReminderTimestamp, generateReminderId, getReminderTimestamp, isReminderVisible, saveCurrentPhaseState } from './dayNightTracking.js';
+import { addReminderTimestamp, generateReminderId, isReminderVisible, saveCurrentPhaseState } from './dayNightTracking.js';
 import { updateGrimoire } from './grimoire.js';
 import { createTokenGridItem } from './ui/tokenGridItem.js';
 import { CLICK_EXPAND_SUPPRESS_MS } from './constants.js';
@@ -289,7 +289,6 @@ export function createReminderElement({
   onClick,
   onLongPress,
   dataset = {},
-  timestamp,
   grimoireState,
   // token specific
   radiusFactor,
@@ -357,13 +356,6 @@ export function createReminderElement({
     element.dataset[k] = v;
   });
 
-  if (timestamp) {
-    const timestampEl = document.createElement('span');
-    timestampEl.className = 'reminder-timestamp';
-    timestampEl.textContent = timestamp;
-    element.appendChild(timestampEl);
-  }
-
   if (onClick || onLongPress) {
     setupInteractiveElement({
       element,
@@ -407,9 +399,6 @@ export function renderRemindersForPlayer({ li, grimoireState, playerIndex }) {
     visibleRemindersCount++;
 
     const isCustom = reminder.id === 'custom-note' || reminder.type === 'text';
-    const timestamp = (grimoireState.dayNightTracking && grimoireState.dayNightTracking.enabled)
-      ? getReminderTimestamp(grimoireState, reminder.reminderId)
-      : null;
 
     const onTap = (e, targetElement) => {
       const parentLi = li;
@@ -462,7 +451,6 @@ export function renderRemindersForPlayer({ li, grimoireState, playerIndex }) {
       image: reminder.image,
       rotation: reminder.rotation,
       isCustomIcon: isCustom,
-      timestamp,
       grimoireState,
       playerIndex,
       reminderIndex: idx,

--- a/styles/day-night-tracking.css
+++ b/styles/day-night-tracking.css
@@ -320,21 +320,6 @@ body.character-panel-open .display-settings-toggle.single-toggle {
   }
 }
 
-/* Reminder Timestamps */
-.reminder-timestamp {
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  background: #D4AF37;
-  color: #1a1a1a;
-  font-size: 10px;
-  font-weight: bold;
-  padding: 2px 6px;
-  border-radius: 10px;
-  z-index: 10;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
 /* Night Reminder Buttons */
 .token-reminder {
   --reminder-size: calc(var(--player-token-size) * 0.2);

--- a/tests/14_day_night_tracking.cy.js
+++ b/tests/14_day_night_tracking.cy.js
@@ -16,7 +16,6 @@ describe('Day/Night Tracking Feature', () => {
 
       // Grimoire should look normal when toggle is off
       cy.get('[data-testid="day-night-slider"]').should('have.css', 'display', 'none');
-      cy.get('.reminder-timestamp').should('not.exist');
     });
 
     it('should enable/disable day/night tracking when clicked', () => {
@@ -142,65 +141,6 @@ describe('Day/Night Tracking Feature', () => {
           expect(rect.left).to.be.gte(0);
         });
       });
-    });
-  });
-
-  describe('Reminder Timestamps', () => {
-    beforeEach(() => {
-      // Enable day/night tracking
-      cy.get('[data-testid="day-night-toggle"]').click({ force: true });
-
-      // Assign a character to first player
-      cy.get('.player-token').first().click({ force: true });
-      cy.get('#character-grid .token').should('be.visible');
-      cy.get('#character-grid .token').first().click();
-
-      // Wait for character to be assigned
-      cy.get('li').first().find('.player-token').should('have.attr', 'style').and('include', 'background-image');
-    });
-
-    it('should add timestamps to reminder tokens when tracking is enabled', () => {
-      // Add a reminder in N1 (Alt+click for text reminder)
-      cy.get('li').first().find('.reminder-placeholder').click({ altKey: true, force: true });
-      cy.get('#text-reminder-modal').should('be.visible');
-      cy.get('#reminder-text-input').type('Test reminder N1');
-      cy.get('[data-testid="save-text-reminder"]').click();
-
-      // Reminder should show N1 timestamp
-      cy.get('li').first().find('.text-reminder').should('contain', 'N1');
-
-      // Move to D1
-      cy.get('[data-testid="add-phase-button"]').click();
-
-      // Add another reminder in D1
-      cy.get('li').eq(1).find('.reminder-placeholder').click({ altKey: true });
-      cy.get('#text-reminder-modal').should('be.visible');
-      cy.get('#reminder-text-input').type('Test reminder D1');
-      cy.get('[data-testid="save-text-reminder"]').click();
-
-      // New reminder should show D1 timestamp
-      cy.get('li').eq(1).find('.text-reminder').should('contain', 'D1');
-
-      // First reminder should still show N1
-      cy.get('li').first().find('.text-reminder').should('contain', 'N1');
-    });
-
-    it('should not show timestamps when tracking is disabled', () => {
-      // Add a reminder
-      cy.get('li').first().find('.reminder-placeholder').click({ altKey: true, force: true });
-      cy.get('#text-reminder-modal').should('be.visible');
-      cy.get('#reminder-text-input').type('Test reminder');
-      cy.get('[data-testid="save-text-reminder"]').click();
-
-      // Reminder should show timestamp
-      cy.get('li').first().find('.text-reminder').should('contain', 'N1');
-
-      // Disable tracking
-      cy.get('[data-testid="day-night-toggle"]').click({ force: true });
-
-      // Reminder should not show timestamp
-      cy.get('li').first().find('.text-reminder').should('not.contain', 'N1');
-      cy.get('.reminder-timestamp').should('not.exist');
     });
   });
 
@@ -422,8 +362,16 @@ describe('Day/Night Tracking Feature', () => {
       // Current phase should be N2
       cy.get('[data-testid="current-phase"]').should('contain', 'N2');
 
-      // Reminder timestamps should be preserved
-      cy.get('.text-reminder').should('contain', 'N2');
+      cy.get('.text-reminder').should('contain', 'Persistent reminder');
+
+      // Filtering should still work after reload
+      cy.get('[data-testid="day-night-slider"] input[type="range"]').invoke('val', 1).trigger('input');
+      cy.get('[data-testid="current-phase"]').should('contain', 'D1');
+      cy.get('.text-reminder').should('not.exist');
+
+      cy.get('[data-testid="day-night-slider"] input[type="range"]').invoke('val', 2).trigger('input');
+      cy.get('[data-testid="current-phase"]').should('contain', 'N2');
+      cy.get('.text-reminder').should('contain', 'Persistent reminder');
     });
   });
 });


### PR DESCRIPTION
- Improve day/night phase controls so the add button advances through existing phases and only creates a new phase when you’re already at the latest one
- Make the day/night slider controls more resilient on small screens so the add button doesn’t collapse or get squeezed out
- Remove the day/night-added badge shown on reminder tokens to reduce visual noise