### PR TITLE
Decouple script traveler toggle from grimoire game state

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import { INCLUDE_TRAVELLERS_KEY, MODE_STORAGE_KEY } from './constants.js';
+import { rebuildAllRoles } from './character.js';
 import { setupGrimoire, updateGrimoire } from './grimoire.js';
 import { renderSetupInfo } from './utils/setup.js';
 import { repositionPlayers } from './ui/layout.js';
@@ -70,6 +71,7 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     if (saved && Array.isArray(saved.players) && saved.players.length) {
       setupGrimoire({ grimoireState, grimoireHistoryList, count: saved.players.length });
       grimoireState.players = saved.players;
+      rebuildAllRoles({ grimoireState });
       updateGrimoire({ grimoireState });
       repositionPlayers({ grimoireState });
       renderSetupInfo({ grimoireState });

--- a/src/character.js
+++ b/src/character.js
@@ -161,6 +161,7 @@ export const assignCharacter = withStateSave(({ grimoireState, roleId }) => {
       return;
     }
     grimoireState.players[grimoireState.selectedPlayerIndex].character = roleId;
+    rebuildAllRoles({ grimoireState });
     grimoireState.gameStarted = true;
     console.log(`Assigned character ${roleId} to player ${grimoireState.selectedPlayerIndex}`);
 
@@ -174,14 +175,22 @@ export const assignCharacter = withStateSave(({ grimoireState, roleId }) => {
   }
 });
 
-export function applyTravellerToggleAndRefresh({ grimoireState }) {
+export function rebuildAllRoles({ grimoireState }) {
   grimoireState.allRoles = { ...(grimoireState.baseRoles || {}) };
-  if (grimoireState.scriptTravellerRoles) {
-    grimoireState.allRoles = { ...grimoireState.allRoles, ...grimoireState.scriptTravellerRoles };
+  // Only include travelers that are actually assigned to players
+  if (Array.isArray(grimoireState.players)) {
+    for (const player of grimoireState.players) {
+      if (!player?.character) continue;
+      const role = (grimoireState.scriptTravellerRoles && grimoireState.scriptTravellerRoles[player.character])
+        || (grimoireState.extraTravellerRoles && grimoireState.extraTravellerRoles[player.character]);
+      if (role && role.team === 'traveller') {
+        grimoireState.allRoles[role.id] = role;
+      }
+    }
   }
-  if (grimoireState.includeTravellers) {
-    grimoireState.allRoles = { ...grimoireState.allRoles, ...(grimoireState.extraTravellerRoles || {}) };
-  }
+}
+
+export function applyTravellerToggleAndRefresh({ grimoireState }) {
   if (Array.isArray(grimoireState.scriptData)) displayScript({ data: grimoireState.scriptData, grimoireState }).catch(console.error);
 }
 
@@ -424,11 +433,11 @@ export const loadAllCharacters = withStateSave(async ({ grimoireState }) => {
       });
     }
 
-    console.log(`Loaded ${Object.keys(grimoireState.allRoles).length} characters from all teams`);
-
     // Create a pseudo-script data array with all character IDs
     grimoireState.scriptData = [{ id: '_meta', name: 'All Characters', author: 'System' }, ...characterIds];
-    // Apply traveller toggle to compute allRoles and render
+    rebuildAllRoles({ grimoireState });
+    console.log(`Loaded ${Object.keys(grimoireState.allRoles).length} characters from all teams`);
+    // Render the character sheet display
     applyTravellerToggleAndRefresh({ grimoireState });
 
     loadStatus.textContent = `Loaded ${Object.keys(grimoireState.allRoles).length} characters successfully`;

--- a/src/playerSetup.js
+++ b/src/playerSetup.js
@@ -1,4 +1,5 @@
 import { withStateSave } from './app.js';
+import { rebuildAllRoles } from './character.js';
 import { resetGrimoire, updateGrimoire } from './grimoire.js';
 import { renderTokenElement } from './ui/tokenRendering.js';
 import { resolveAssetPath } from '../utils.js';
@@ -767,6 +768,7 @@ export function initPlayerSetup({ grimoireState }) {
           // Assign traveller to player
           if (grimoireState.players && grimoireState.players[forIdx]) {
             grimoireState.players[forIdx].character = roleId;
+            rebuildAllRoles({ grimoireState });
           }
 
           // Remove traveller from bag so it can't be assigned again

--- a/src/script.js
+++ b/src/script.js
@@ -1,4 +1,4 @@
-import { processScriptCharacters, applyTravellerToggleAndRefresh } from './character.js';
+import { processScriptCharacters, applyTravellerToggleAndRefresh, rebuildAllRoles } from './character.js';
 import { resolveAssetPath, isExcludedScriptName } from '../utils.js';
 import { withStateSave } from './app.js';
 import { renderSetupInfo } from './utils/setup.js';
@@ -8,6 +8,16 @@ export async function displayScript({ data, grimoireState }) {
   const characterSheet = document.getElementById('character-sheet');
   console.log('Displaying script with', data.length, 'characters');
   characterSheet.innerHTML = '';
+
+  // Compute display roles for the character sheet independently of allRoles.
+  // The script sidebar toggle only affects this view, not the grimoire or game state.
+  let displayRoles = { ...(grimoireState.baseRoles || {}) };
+  if (grimoireState.scriptTravellerRoles) {
+    displayRoles = { ...displayRoles, ...grimoireState.scriptTravellerRoles };
+  }
+  if (grimoireState.includeTravellers) {
+    displayRoles = { ...displayRoles, ...(grimoireState.extraTravellerRoles || {}) };
+  }
 
   const metaEntry = Array.isArray(data) ? data.find(x => x && typeof x === 'object' && x.id === '_meta') : null;
   const scriptTitle = metaEntry?.name || grimoireState.scriptMetaName || '';
@@ -73,7 +83,7 @@ export async function displayScript({ data, grimoireState }) {
     });
 
     const rolesToRender = [];
-    Object.values(grimoireState.allRoles || {}).forEach(role => {
+    Object.values(displayRoles || {}).forEach(role => {
       if (!role || !role.id || role.id === '_meta') return;
       const orderFromData = officialOrderMap.get(role.id);
       if (orderFromData !== undefined) {
@@ -108,10 +118,10 @@ export async function displayScript({ data, grimoireState }) {
       characterSheet.appendChild(roleEl);
     });
 
-    displayJinxes({ jinxData, grimoireState, characterSheet });
+    displayJinxes({ jinxData, grimoireState, characterSheet, displayRoles });
   } else {
     const teamGroups = {};
-    Object.values(grimoireState.allRoles).forEach(role => {
+    Object.values(displayRoles).forEach(role => {
       if (!teamGroups[role.team]) {
         teamGroups[role.team] = [];
       }
@@ -145,7 +155,7 @@ export async function displayScript({ data, grimoireState }) {
         }
 
         if (team === 'demon') {
-          displayJinxes({ jinxData, grimoireState, characterSheet });
+          displayJinxes({ jinxData, grimoireState, characterSheet, displayRoles });
         }
       });
     } else {
@@ -284,6 +294,7 @@ export const processScriptData = withStateSave(async ({ data, addToHistory = fal
   console.log('Processing script with', data.length, 'characters');
   await processScriptCharacters({ characterIds: data, grimoireState });
 
+  rebuildAllRoles({ grimoireState });
   console.log('Total roles processed:', Object.keys(grimoireState.allRoles).length);
   applyTravellerToggleAndRefresh({ grimoireState });
   renderSetupInfo({ grimoireState });
@@ -500,9 +511,10 @@ export async function loadScriptFile({ event, grimoireState }) {
   reader.readAsText(file);
 }
 
-function displayJinxes({ jinxData, grimoireState, characterSheet }) {
+function displayJinxes({ jinxData, grimoireState, characterSheet, displayRoles }) {
+  const rolesToUse = displayRoles || grimoireState.allRoles;
   const scriptCharacterIds = new Set();
-  Object.values(grimoireState.allRoles).forEach(role => {
+  Object.values(rolesToUse).forEach(role => {
     scriptCharacterIds.add(role.id);
   });
 
@@ -532,8 +544,8 @@ function displayJinxes({ jinxData, grimoireState, characterSheet }) {
       const jinxEl = document.createElement('div');
       jinxEl.className = 'jinx-entry';
 
-      const char1Role = grimoireState.allRoles[jinx.char1];
-      const char2Role = grimoireState.allRoles[jinx.char2];
+      const char1Role = rolesToUse[jinx.char1];
+      const char2Role = rolesToUse[jinx.char2];
 
       jinxEl.innerHTML = `
         <div class="jinx-characters">


### PR DESCRIPTION
The script sidebar's "Include Travellers" checkbox now only affects the
character sheet display, not allRoles or the grimoire. Travelers are
added to allRoles only when actually assigned to players via character
selection or player setup, making the game state reflect real assignments.

- Add rebuildAllRoles() that computes allRoles = baseRoles + assigned travelers
- displayScript() computes its own displayRoles for character sheet rendering
- applyTravellerToggleAndRefresh() no longer mutates allRoles
- Call rebuildAllRoles after character assignment, player setup, state restore

https://claude.ai/code/session_0141QuwnCo5QCmEdosJMAgHG