### PR TITLE
fix: update bump-cache workflow to use version.json instead of hardcoded constant

### DIFF
--- a/.github/workflows/bump-cache.yml
+++ b/.github/workflows/bump-cache.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Update cache version
         shell: bash
         run: |
-          CURRENT_VERSION=$(grep -oP "const CACHE_NAME = 'botc-party-grimoire-v\K[0-9]+" service-worker.js)
-          if [ -z "$CURRENT_VERSION" ]; then
-            echo "Failed to determine CURRENT_VERSION from service-worker.js" >&2
+          CURRENT_VERSION=$(jq '.uiVersion' version.json)
+          if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
+            echo "Failed to determine uiVersion from version.json" >&2
             exit 1
           fi
           NEW_VERSION=$((CURRENT_VERSION + 1))
-          sed -i "s/const CACHE_NAME = 'botc-party-grimoire-v${CURRENT_VERSION}'/const CACHE_NAME = 'botc-party-grimoire-v${NEW_VERSION}'/" service-worker.js
+          jq --argjson v "$NEW_VERSION" '.uiVersion = $v' version.json > version.json.tmp && mv version.json.tmp version.json
           echo "Updated cache version from v${CURRENT_VERSION} to v${NEW_VERSION}"
-          grep "const CACHE_NAME" service-worker.js
+          cat version.json
           echo "NEW_VERSION=${NEW_VERSION}" >> "$GITHUB_ENV"
 
       - name: Setup Node.js
@@ -55,12 +55,12 @@ jobs:
       - name: Commit and push change
         shell: bash
         run: |
-          if git diff --quiet service-worker.js; then
+          if git diff --quiet version.json asset-manifest.json; then
             echo "No cache version change to commit."
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add service-worker.js asset-manifest.json
+            git add version.json asset-manifest.json
             git commit -m "chore: bump service worker cache to v${NEW_VERSION}"
             git push origin HEAD:main
           fi


### PR DESCRIPTION
The service worker was refactored to read cache version dynamically from
version.json (uiVersion), but the bump-cache workflow still looked for a
hardcoded `const CACHE_NAME = 'botc-party-grimoire-v...'` in service-worker.js.
This caused the "Update cache version" step to fail with exit code 1.

https://claude.ai/code/session_01Re6X52NcqThQrYSrXqF8xi