### PR TITLE
feat: snapshot/restore grimoire & drop lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ npx eslint --fix
 - Use Conventional Commits (e.g., `feat:`, `fix:`, `docs:`, `refactor:`).
 - Keep the subject line strictly under 80 characters.
 
-4. Require Green Tests Before Commit/Push
+4. If asked to create a branch, create conventional branch name too, starting with prefixes like fix/ refactor/ feat/ etc.
+
+5. Require Green Tests Before Commit/Push
 
 - Always run the full Cypress suite (`./test-parallel.sh`) before committing or pushing.
 - Use `./test-parallel.sh` for fast parallel execution of the full suite.
@@ -34,7 +36,12 @@ npx eslint --fix
 - If any tests fail, fix the code or tests, then re-run until all pass.
 - Do not commit/push with failing tests.
 
-5. Static Imports Only
+5. No AI Attribution in Commits
+
+- Commits must only use the locally configured git user profile.
+- Never include AI agent names, co-author tags, or any other AI attribution in commit messages or metadata.
+
+7. Static Imports Only
 
 - Do not use dynamic `require`/`import()` within functions or blocks.
 - Always place all imports at the top of the module.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/index.html
+++ b/index.html
@@ -172,6 +172,11 @@
         aria-label="Toggle day/night tracking" aria-pressed="false" title="Toggle day/night tracking">
         <i class="fas fa-moon"></i>
       </button>
+      <button id="grimoire-snapshot-toggle" data-testid="grimoire-snapshot-toggle"
+        class="button grimoire-snapshot-toggle" aria-label="Make temporary changes to the grimoire"
+        aria-pressed="false" title="Make temporary changes to the grimoire" style="display:none;">
+        <i class="fas fa-camera" aria-hidden="true"></i>
+      </button>
 	      <button id="display-settings-toggle" data-testid="display-settings-toggle" class="button display-settings-toggle"
 	        aria-label="Adjust display settings" aria-pressed="false" title="Adjust display settings">
 	        <i class="fas fa-sliders-h"></i>

--- a/index.html
+++ b/index.html
@@ -217,6 +217,10 @@
           <ul id="player-circle" class="circle"></ul>
           <div id="setup-info" aria-live="polite"></div>
         </div>
+        <div id="grimoire-hidden-banner" data-testid="grimoire-hidden-banner"
+          class="grimoire-hidden-banner" aria-hidden="true">
+          <span>GRIMOIRE HIDDEN</span>
+        </div>
       </div>
       <div id="day-night-slider" data-testid="day-night-slider" class="day-night-slider">
         <div class="slider-container">

--- a/index.html
+++ b/index.html
@@ -72,7 +72,6 @@
           <a class="button" id="open-rulebook" style="text-align:center;" href="https://drive.google.com/file/d/1kyOY-4PmSnQNoH3axyq1cEjVZ2T3kmlm/view" target="_blank" rel="noopener noreferrer">Rulebook</a>
           <button class="button" id="end-game">End Game</button>
           <button class="button" id="reveal-assignments">Reveal Characters</button>
-          <button class="button" id="grimoire-lock-toggle" style="display:none;">Lock Grimoire</button>
         </div>
         <div style="display:flex; flex-direction: column; gap:8px; margin-top:8px;">
           <button class="button" id="reset-grimoire">Reset Grimoire</button>

--- a/script.js
+++ b/script.js
@@ -3,8 +3,7 @@ import { loadAppState, saveAppState } from './src/app.js';
 import { hideCharacterModal, loadAllCharacters, onIncludeTravellersChange, populateCharacterGrid } from './src/character.js';
 import { INCLUDE_TRAVELLERS_KEY, isTouchDevice, MODE_STORAGE_KEY } from './src/constants.js';
 import { addReminderTimestamp, generateReminderId, initDayNightTracking, updateDayNightUI } from './src/dayNightTracking.js';
-import { applyGrimoireHiddenState, applyGrimoireLockedState, resetGrimoire, showGrimoire, toggleGrimoireHidden, toggleGrimoireLocked, updateGrimoire } from './src/grimoire.js';
-import { ensureGrimoireUnlocked } from './src/grimoireLock.js';
+import { applyGrimoireHiddenState, resetGrimoire, showGrimoire, toggleGrimoireHidden, updateGrimoire } from './src/grimoire.js';
 import { initExportImport } from './src/history/exportImport.js';
 import { addGrimoireHistoryListListeners, renderGrimoireHistory, snapshotCurrentGrimoire } from './src/history/grimoire.js';
 import { loadHistories } from './src/history/index.js';
@@ -254,7 +253,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const displaySettingsToggleBtn = document.getElementById('display-settings-toggle');
     const revealToggleBtn = document.getElementById('reveal-assignments');
     const revealSelectedBtn = document.getElementById('reveal-selected-characters');
-    const grimoireLockToggleBtn = document.getElementById('grimoire-lock-toggle');
 
     const grimoireState = {
       includeTravellers: false,
@@ -278,7 +276,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       outsideCollapseHandlerInstalled: false,
       mode: 'player',
       grimoireHidden: false,
-      grimoireLocked: false,
       gameStarted: false,
       displaySettings: { tokenScale: 1, playerNameScale: 1, circleScale: 1 }
     };
@@ -321,13 +318,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         revealToggleBtn.textContent = hidden ? 'Show Grimoire' : 'Hide Grimoire';
         revealToggleBtn.title = hidden ? 'Reveal characters to players' : 'Hide characters on this device';
         revealToggleBtn.setAttribute('aria-pressed', String(hidden));
-      }
-      if (grimoireLockToggleBtn) {
-        const locked = !!grimoireState.grimoireLocked;
-        grimoireLockToggleBtn.style.display = isPlayer ? 'none' : '';
-        grimoireLockToggleBtn.textContent = locked ? 'Unlock Grimoire' : 'Lock Grimoire';
-        grimoireLockToggleBtn.title = locked ? 'Unlock to allow grimoire changes' : 'Lock to prevent lineup changes';
-        grimoireLockToggleBtn.setAttribute('aria-pressed', String(locked));
       }
     };
 
@@ -389,14 +379,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         updateGrimoireControlButtons();
       });
     }
-    if (grimoireLockToggleBtn) {
-      grimoireLockToggleBtn.addEventListener('click', () => {
-        if (grimoireState.mode === 'player') return;
-        toggleGrimoireLocked({ grimoireState });
-        updateGrimoireControlButtons();
-      });
-    }
-
     if (modeStorytellerRadio && modePlayerRadio) {
       applyModeUI();
       const onModeChange = (e) => {
@@ -814,7 +796,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     saveReminderBtn.onclick = () => {
-      if (!ensureGrimoireUnlocked({ grimoireState })) return;
       const text = reminderTextInput.value.trim();
       const { playerIndex, reminderIndex } = grimoireState.editingReminder;
       if (text) {
@@ -1069,7 +1050,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     applyModeUI();
     applyGrimoireHiddenUI();
-    applyGrimoireLockedState({ grimoireState });
     updateGrimoireControlButtons();
     try {
       updatePreGameClass();

--- a/script.js
+++ b/script.js
@@ -348,6 +348,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (modeStorytellerRadio) modeStorytellerRadio.checked = grimoireState.mode !== 'player';
       if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
       const isPlayer = grimoireState.mode === 'player';
+      try {
+        document.body.classList.toggle('mode-player', isPlayer);
+        document.body.classList.toggle('mode-storyteller', !isPlayer);
+      } catch (_) { }
       if (dayNightToggleBtn) dayNightToggleBtn.style.display = isPlayer ? 'none' : '';
       if (displaySettingsToggleBtn) {
         if (isPlayer) {

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ import { loadAppState, saveAppState } from './src/app.js';
 import { hideCharacterModal, loadAllCharacters, onIncludeTravellersChange, populateCharacterGrid } from './src/character.js';
 import { INCLUDE_TRAVELLERS_KEY, isTouchDevice, MODE_STORAGE_KEY } from './src/constants.js';
 import { addReminderTimestamp, generateReminderId, initDayNightTracking, updateDayNightUI } from './src/dayNightTracking.js';
-import { applyGrimoireHiddenState, resetGrimoire, showGrimoire, toggleGrimoireHidden, updateGrimoire } from './src/grimoire.js';
+import { applyGrimoireHiddenState, applyGrimoireSnapshotState, hasGrimoireSnapshot, resetGrimoire, restoreGrimoireSnapshot, showGrimoire, takeGrimoireSnapshot, toggleGrimoireHidden, updateGrimoire } from './src/grimoire.js';
 import { initExportImport } from './src/history/exportImport.js';
 import { addGrimoireHistoryListListeners, renderGrimoireHistory, snapshotCurrentGrimoire } from './src/history/grimoire.js';
 import { loadHistories } from './src/history/index.js';
@@ -253,6 +253,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const displaySettingsToggleBtn = document.getElementById('display-settings-toggle');
     const revealToggleBtn = document.getElementById('reveal-assignments');
     const revealSelectedBtn = document.getElementById('reveal-selected-characters');
+    const grimoireSnapshotToggleBtn = document.getElementById('grimoire-snapshot-toggle');
 
     const grimoireState = {
       includeTravellers: false,
@@ -276,6 +277,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       outsideCollapseHandlerInstalled: false,
       mode: 'player',
       grimoireHidden: false,
+      tempSnapshot: null,
       gameStarted: false,
       displaySettings: { tokenScale: 1, playerNameScale: 1, circleScale: 1 }
     };
@@ -321,6 +323,27 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     };
 
+    const updateSnapshotToggleUI = () => {
+      if (!grimoireSnapshotToggleBtn) return;
+      const isStoryteller = grimoireState.mode === 'storyteller';
+      grimoireSnapshotToggleBtn.style.display = isStoryteller ? '' : 'none';
+      const active = hasGrimoireSnapshot(grimoireState);
+      grimoireSnapshotToggleBtn.setAttribute('aria-pressed', String(active));
+      grimoireSnapshotToggleBtn.classList.toggle('active', active);
+      grimoireSnapshotToggleBtn.title = active
+        ? 'Restore grimoire to before temporary changes'
+        : 'Make temporary changes to the grimoire';
+      grimoireSnapshotToggleBtn.setAttribute(
+        'aria-label',
+        active ? 'Restore grimoire to before temporary changes' : 'Make temporary changes to the grimoire'
+      );
+      const icon = grimoireSnapshotToggleBtn.querySelector('i');
+      if (icon) {
+        icon.className = active ? 'fas fa-rotate-left' : 'fas fa-camera';
+      }
+      applyGrimoireSnapshotState({ grimoireState });
+    };
+
     const applyModeUI = () => {
       if (modeStorytellerRadio) modeStorytellerRadio.checked = grimoireState.mode !== 'player';
       if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
@@ -347,6 +370,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       try { updateBluffAttentionState({ grimoireState }); } catch (_) { }
       updateGrimoireControlButtons();
+      updateSnapshotToggleUI();
     };
     function applyGrimoireHiddenUI() {
       applyGrimoireHiddenState({ grimoireState });
@@ -377,6 +401,17 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (grimoireState.mode !== 'player') return;
         toggleGrimoireHidden({ grimoireState });
         updateGrimoireControlButtons();
+      });
+    }
+    if (grimoireSnapshotToggleBtn) {
+      grimoireSnapshotToggleBtn.addEventListener('click', () => {
+        if (grimoireState.mode !== 'storyteller') return;
+        if (hasGrimoireSnapshot(grimoireState)) {
+          restoreGrimoireSnapshot({ grimoireState });
+        } else {
+          takeGrimoireSnapshot({ grimoireState });
+        }
+        updateSnapshotToggleUI();
       });
     }
     if (modeStorytellerRadio && modePlayerRadio) {
@@ -632,6 +667,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       applyModeUI();
       updateButtonStates();
       updatePreGameClass();
+      updateSnapshotToggleUI();
     });
 
     if (endGameBtn) endGameBtn.addEventListener('click', () => { if (endGameModal) endGameModal.style.display = 'flex'; });
@@ -1033,6 +1069,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     applyModeUI();
     applyGrimoireHiddenUI();
     updateGrimoireControlButtons();
+    updateSnapshotToggleUI();
     try {
       updatePreGameClass();
       if (window.updatePreGameOverlayMessage) window.updatePreGameOverlayMessage();

--- a/script.js
+++ b/script.js
@@ -726,18 +726,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       grimoireState.gameStarted = false;
       applyModeUI();
       try { updateBluffAttentionState({ grimoireState }); } catch (_) { }
-      // Gate further setup until reset (winner flag presence is the gate)
-      try {
-        const openPlayerSetupBtn2 = document.getElementById('open-player-setup');
-        if (openPlayerSetupBtn2) {
-          openPlayerSetupBtn2.disabled = true;
-          openPlayerSetupBtn2.title = 'Reset grimoire to configure a new game';
-        }
-        if (revealSelectedBtn) {
-          revealSelectedBtn.disabled = true;
-          revealSelectedBtn.title = 'Reset grimoire to configure a new game';
-        }
-      } catch (_) { }
     }
 
     if (goodWinsBtn) goodWinsBtn.addEventListener('click', () => declareWinner('good'));
@@ -750,14 +738,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (openPlayerSetupBtn) {
         const sel = grimoireState.playerSetup || {};
         const selectionComplete = !!sel.selectionComplete;
-        openPlayerSetupBtn.disabled = !!grimoireState.winner || selectionComplete;
-        if (grimoireState.winner) {
-          openPlayerSetupBtn.title = 'Reset grimoire to configure a new game';
-        } else if (selectionComplete) {
-          openPlayerSetupBtn.title = 'Setup complete. Reset the grimoire to start a new setup.';
-        } else {
-          openPlayerSetupBtn.title = '';
-        }
+        openPlayerSetupBtn.disabled = selectionComplete;
+        openPlayerSetupBtn.title = selectionComplete ? 'Setup complete. Reset the grimoire to start a new setup.' : '';
       }
 
       if (revealSelectedBtn) {
@@ -766,8 +748,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const selectionRevealed = !!sel.revealed;
         const shouldShow = selectionComplete && !selectionRevealed;
         revealSelectedBtn.style.display = shouldShow ? '' : 'none';
-        revealSelectedBtn.disabled = !!grimoireState.winner;
-        revealSelectedBtn.title = revealSelectedBtn.disabled ? 'Reset grimoire to configure a new game' : '';
+        revealSelectedBtn.disabled = false;
+        revealSelectedBtn.title = '';
       }
 
       if (endGameBtn) endGameBtn.style.display = grimoireState.winner ? 'none' : '';

--- a/src/app.js
+++ b/src/app.js
@@ -102,8 +102,10 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     if (saved && saved.winner) {
       grimoireState.winner = saved.winner;
     }
-    if (saved && saved.tempSnapshot) {
-      grimoireState.tempSnapshot = saved.tempSnapshot;
+    if (saved && Object.prototype.hasOwnProperty.call(saved, 'tempSnapshot')) {
+      grimoireState.tempSnapshot = saved.tempSnapshot || null;
+    } else {
+      grimoireState.tempSnapshot = null;
     }
   } catch (_) { } finally { grimoireState.isRestoringState = false; }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -46,7 +46,6 @@ export function saveAppState({ grimoireState }) {
       bluffs: grimoireState.bluffs || [null, null, null],
       mode: grimoireState.mode || 'player',
       grimoireHidden: !!grimoireState.grimoireHidden,
-      grimoireLocked: !!grimoireState.grimoireLocked,
       playerSetup: grimoireState.playerSetup || { bag: [], assignments: [], revealed: false },
       gameStarted: !!grimoireState.gameStarted,
       winner: grimoireState.winner || null
@@ -90,9 +89,6 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     }
     if (saved && typeof saved.grimoireHidden === 'boolean') {
       grimoireState.grimoireHidden = !!saved.grimoireHidden;
-    }
-    if (saved && typeof saved.grimoireLocked === 'boolean') {
-      grimoireState.grimoireLocked = !!saved.grimoireLocked;
     }
     if (saved && saved.playerSetup) {
       grimoireState.playerSetup = saved.playerSetup;

--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,8 @@ export function saveAppState({ grimoireState }) {
       grimoireHidden: !!grimoireState.grimoireHidden,
       playerSetup: grimoireState.playerSetup || { bag: [], assignments: [], revealed: false },
       gameStarted: !!grimoireState.gameStarted,
-      winner: grimoireState.winner || null
+      winner: grimoireState.winner || null,
+      tempSnapshot: grimoireState.tempSnapshot || null
     };
     localStorage.setItem('botcAppStateV1', JSON.stringify(state));
     try { localStorage.setItem(INCLUDE_TRAVELLERS_KEY, grimoireState.includeTravellers ? '1' : '0'); } catch (_) { }
@@ -100,6 +101,9 @@ export async function loadAppState({ grimoireState, grimoireHistoryList }) {
     }
     if (saved && saved.winner) {
       grimoireState.winner = saved.winner;
+    }
+    if (saved && saved.tempSnapshot) {
+      grimoireState.tempSnapshot = saved.tempSnapshot;
     }
   } catch (_) { } finally { grimoireState.isRestoringState = false; }
 }

--- a/src/bluffTokens.js
+++ b/src/bluffTokens.js
@@ -39,7 +39,6 @@ export function createBluffToken({ grimoireState, index }) {
     onTap: () => {
       if (!canOpenModal({
         grimoireState,
-        requiresUnlocked: true,
         requiresNoWinner: true
       })) {
         return;
@@ -91,7 +90,6 @@ export function updateBluffToken({ grimoireState, index, updateAttention = true 
 export function openBluffCharacterModal({ grimoireState, bluffIndex }) {
   if (!canOpenModal({
     grimoireState,
-    requiresUnlocked: true,
     requiresScript: true
   })) {
     return;
@@ -146,10 +144,6 @@ export function openBluffCharacterModal({ grimoireState, bluffIndex }) {
 }
 
 export const assignBluffCharacter = withStateSave(({ grimoireState, roleId }) => {
-  if (!canOpenModal({ grimoireState, requiresUnlocked: true })) {
-    hideCharacterModal({ grimoireState, clearBluffSelection: true });
-    return;
-  }
   if (grimoireState.selectedBluffIndex !== undefined && grimoireState.selectedBluffIndex > -1) {
     if (!grimoireState.bluffs) {
       grimoireState.bluffs = [null, null, null];

--- a/src/bluffTokens.js
+++ b/src/bluffTokens.js
@@ -37,10 +37,7 @@ export function createBluffToken({ grimoireState, index }) {
   setupInteractiveElement({
     element: token,
     onTap: () => {
-      if (!canOpenModal({
-        grimoireState,
-        requiresNoWinner: true
-      })) {
+      if (!canOpenModal({ grimoireState })) {
         return;
       }
       openBluffCharacterModal({ grimoireState, bluffIndex: index });

--- a/src/character.js
+++ b/src/character.js
@@ -7,7 +7,6 @@ import { withStateSave } from './app.js';
 import { saveCurrentPhaseState } from './dayNightTracking.js';
 import { assignBluffCharacter } from './bluffTokens.js';
 import { renderTokenElement } from './ui/tokenRendering.js';
-import { ensureGrimoireUnlocked } from './grimoireLock.js';
 import { canOpenModal } from './utils/validation.js';
 
 export function populateCharacterGrid({ grimoireState }) {
@@ -141,19 +140,11 @@ export const assignCharacter = withStateSave(({ grimoireState, roleId }) => {
   }
 
   if (grimoireState.selectedBluffIndex !== undefined && grimoireState.selectedBluffIndex > -1) {
-    if (!ensureGrimoireUnlocked({ grimoireState })) {
-      hideCharacterModal({ grimoireState, clearBluffSelection: true });
-      return;
-    }
     assignBluffCharacter({ grimoireState, roleId });
     return;
   }
 
   if (grimoireState.selectedPlayerIndex > -1) {
-    if (!ensureGrimoireUnlocked({ grimoireState })) {
-      hideCharacterModal({ grimoireState });
-      return;
-    }
     grimoireState.players[grimoireState.selectedPlayerIndex].character = roleId;
     grimoireState.gameStarted = true;
     console.log(`Assigned character ${roleId} to player ${grimoireState.selectedPlayerIndex}`);
@@ -343,7 +334,6 @@ export function openCharacterModal({ grimoireState, playerIndex }) {
 
   if (!canOpenModal({
     grimoireState,
-    requiresUnlocked: true,
     requiresScript: true,
     requiresNotHidden: true
   })) {

--- a/src/currentGame/exportImport.js
+++ b/src/currentGame/exportImport.js
@@ -1,6 +1,6 @@
 import { loadAppState } from '../app.js';
 import { INCLUDE_TRAVELLERS_KEY, MODE_STORAGE_KEY } from '../constants.js';
-import { applyGrimoireHiddenState, applyGrimoireLockedState } from '../grimoire.js';
+import { applyGrimoireHiddenState } from '../grimoire.js';
 import { updateBluffAttentionState } from '../bluffTokens.js';
 
 function getStatusEl() {
@@ -49,7 +49,6 @@ function normalizeImportedGameState(data) {
     bluffs: Array.isArray(state.bluffs) ? state.bluffs : [null, null, null],
     mode: state.mode === 'player' ? 'player' : 'storyteller',
     grimoireHidden: !!state.grimoireHidden,
-    grimoireLocked: !!state.grimoireLocked,
     playerSetup: state.playerSetup || { bag: [], assignments: [], revealed: false },
     gameStarted: !!state.gameStarted,
     winner: state.winner || null
@@ -64,7 +63,6 @@ function applyModeUi({ grimoireState }) {
   const dayNightSlider = document.getElementById('day-night-slider');
   const openRulebookBtn = document.getElementById('open-rulebook');
   const revealToggleBtn = document.getElementById('reveal-assignments');
-  const grimoireLockToggleBtn = document.getElementById('grimoire-lock-toggle');
 
   if (modeStorytellerRadio) modeStorytellerRadio.checked = grimoireState.mode !== 'player';
   if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
@@ -97,13 +95,6 @@ function applyModeUi({ grimoireState }) {
     revealToggleBtn.title = hidden ? 'Reveal characters to players' : 'Hide characters on this device';
     revealToggleBtn.setAttribute('aria-pressed', String(hidden));
   }
-  if (grimoireLockToggleBtn) {
-    const locked = !!grimoireState.grimoireLocked;
-    grimoireLockToggleBtn.style.display = isPlayer ? 'none' : '';
-    grimoireLockToggleBtn.textContent = locked ? 'Unlock Grimoire' : 'Lock Grimoire';
-    grimoireLockToggleBtn.title = locked ? 'Unlock to allow grimoire changes' : 'Lock to prevent lineup changes';
-    grimoireLockToggleBtn.setAttribute('aria-pressed', String(locked));
-  }
 
   try { updateBluffAttentionState({ grimoireState }); } catch (_) { }
 }
@@ -118,7 +109,6 @@ export function exportCurrentGame({ grimoireState }) {
     bluffs: Array.isArray(grimoireState.bluffs) ? grimoireState.bluffs : [null, null, null],
     mode: grimoireState.mode === 'player' ? 'player' : 'storyteller',
     grimoireHidden: !!grimoireState.grimoireHidden,
-    grimoireLocked: !!grimoireState.grimoireLocked,
     playerSetup: grimoireState.playerSetup || { bag: [], assignments: [], revealed: false },
     gameStarted: !!grimoireState.gameStarted,
     winner: grimoireState.winner || null
@@ -190,7 +180,6 @@ export async function importCurrentGame({ file, grimoireState, grimoireHistoryLi
     bluffs: normalized.bluffs,
     mode: normalized.mode,
     grimoireHidden: normalized.grimoireHidden,
-    grimoireLocked: normalized.grimoireLocked,
     playerSetup: normalized.playerSetup,
     gameStarted: normalized.gameStarted,
     winner: normalized.winner
@@ -202,7 +191,6 @@ export async function importCurrentGame({ file, grimoireState, grimoireHistoryLi
 
   await loadAppState({ grimoireState, grimoireHistoryList });
   try { applyGrimoireHiddenState({ grimoireState }); } catch (_) { }
-  try { applyGrimoireLockedState({ grimoireState }); } catch (_) { }
   try { applyModeUi({ grimoireState }); } catch (_) { }
 
   setStatus({ message: 'Game imported successfully!' });

--- a/src/currentGame/exportImport.js
+++ b/src/currentGame/exportImport.js
@@ -1,6 +1,6 @@
 import { loadAppState } from '../app.js';
 import { INCLUDE_TRAVELLERS_KEY, MODE_STORAGE_KEY } from '../constants.js';
-import { applyGrimoireHiddenState } from '../grimoire.js';
+import { applyGrimoireHiddenState, applyGrimoireSnapshotState } from '../grimoire.js';
 import { updateBluffAttentionState } from '../bluffTokens.js';
 
 function getStatusEl() {
@@ -51,7 +51,8 @@ function normalizeImportedGameState(data) {
     grimoireHidden: !!state.grimoireHidden,
     playerSetup: state.playerSetup || { bag: [], assignments: [], revealed: false },
     gameStarted: !!state.gameStarted,
-    winner: state.winner || null
+    winner: state.winner || null,
+    tempSnapshot: state.tempSnapshot || null
   };
 }
 
@@ -63,6 +64,7 @@ function applyModeUi({ grimoireState }) {
   const dayNightSlider = document.getElementById('day-night-slider');
   const openRulebookBtn = document.getElementById('open-rulebook');
   const revealToggleBtn = document.getElementById('reveal-assignments');
+  const grimoireSnapshotToggleBtn = document.getElementById('grimoire-snapshot-toggle');
 
   if (modeStorytellerRadio) modeStorytellerRadio.checked = grimoireState.mode !== 'player';
   if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
@@ -95,6 +97,24 @@ function applyModeUi({ grimoireState }) {
     revealToggleBtn.title = hidden ? 'Reveal characters to players' : 'Hide characters on this device';
     revealToggleBtn.setAttribute('aria-pressed', String(hidden));
   }
+  if (grimoireSnapshotToggleBtn) {
+    const isStoryteller = !isPlayer;
+    const active = !!grimoireState.tempSnapshot;
+    grimoireSnapshotToggleBtn.style.display = isStoryteller ? '' : 'none';
+    grimoireSnapshotToggleBtn.setAttribute('aria-pressed', String(active));
+    grimoireSnapshotToggleBtn.classList.toggle('active', active);
+    grimoireSnapshotToggleBtn.title = active
+      ? 'Restore grimoire to before temporary changes'
+      : 'Make temporary changes to the grimoire';
+    grimoireSnapshotToggleBtn.setAttribute(
+      'aria-label',
+      active ? 'Restore grimoire to before temporary changes' : 'Make temporary changes to the grimoire'
+    );
+    const icon = grimoireSnapshotToggleBtn.querySelector('i');
+    if (icon) {
+      icon.className = active ? 'fas fa-rotate-left' : 'fas fa-camera';
+    }
+  }
 
   try { updateBluffAttentionState({ grimoireState }); } catch (_) { }
 }
@@ -111,7 +131,8 @@ export function exportCurrentGame({ grimoireState }) {
     grimoireHidden: !!grimoireState.grimoireHidden,
     playerSetup: grimoireState.playerSetup || { bag: [], assignments: [], revealed: false },
     gameStarted: !!grimoireState.gameStarted,
-    winner: grimoireState.winner || null
+    winner: grimoireState.winner || null,
+    tempSnapshot: grimoireState.tempSnapshot || null
   };
 
   const exportData = {
@@ -182,7 +203,8 @@ export async function importCurrentGame({ file, grimoireState, grimoireHistoryLi
     grimoireHidden: normalized.grimoireHidden,
     playerSetup: normalized.playerSetup,
     gameStarted: normalized.gameStarted,
-    winner: normalized.winner
+    winner: normalized.winner,
+    tempSnapshot: normalized.tempSnapshot
   };
 
   try { localStorage.setItem('botcAppStateV1', JSON.stringify(saved)); } catch (_) { }
@@ -191,6 +213,7 @@ export async function importCurrentGame({ file, grimoireState, grimoireHistoryLi
 
   await loadAppState({ grimoireState, grimoireHistoryList });
   try { applyGrimoireHiddenState({ grimoireState }); } catch (_) { }
+  try { applyGrimoireSnapshotState({ grimoireState }); } catch (_) { }
   try { applyModeUi({ grimoireState }); } catch (_) { }
 
   setStatus({ message: 'Game imported successfully!' });

--- a/src/currentGame/exportImport.js
+++ b/src/currentGame/exportImport.js
@@ -70,6 +70,10 @@ function applyModeUi({ grimoireState }) {
   if (modePlayerRadio) modePlayerRadio.checked = grimoireState.mode === 'player';
 
   const isPlayer = grimoireState.mode === 'player';
+  try {
+    document.body.classList.toggle('mode-player', isPlayer);
+    document.body.classList.toggle('mode-storyteller', !isPlayer);
+  } catch (_) { }
   if (dayNightToggleBtn) dayNightToggleBtn.style.display = isPlayer ? 'none' : '';
   if (displaySettingsToggleBtn) {
     if (isPlayer) displaySettingsToggleBtn.classList.add('single-toggle');

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -10,14 +10,12 @@ import { positionInfoIcons, positionTokenReminders } from './ui/tooltip.js';
 import { renderSetupInfo } from './utils/setup.js';
 import { handlePlayerElementTouch } from './ui/touchHelpers.js';
 import { createPlayerListItem } from './ui/playerCircle.js';
-import { ensureGrimoireUnlocked } from './grimoireLock.js';
 import { updatePlayerElement } from './ui/playerUpdate.js';
 import { createSafeClickHandler, attachTouchHandler } from './utils/eventHandlers.js';
 
 try { window.openReminderTokenModal = openReminderTokenModal; } catch (_) { }
 function setupPlayerNameHandlers({ listItem, grimoireState, playerIndex }) {
   const handlePlayerNameClick = withStateSave((_e) => {
-    if (!ensureGrimoireUnlocked({ grimoireState })) return;
     const currentName = grimoireState.players[playerIndex].name;
     const newName = prompt('Enter player name:', currentName);
     if (newName) {
@@ -42,19 +40,6 @@ function setupPlayerNameHandlers({ listItem, grimoireState, playerIndex }) {
 export function applyGrimoireHiddenState({ grimoireState }) {
   try { document.body.classList.toggle('grimoire-hidden', !!grimoireState.grimoireHidden); } catch (_) { }
   updateGrimoire({ grimoireState });
-}
-
-export function applyGrimoireLockedState({ grimoireState }) {
-  try { document.body.classList.toggle('grimoire-locked', !!grimoireState.grimoireLocked); } catch (_) { }
-}
-
-export const setGrimoireLocked = withStateSave(({ grimoireState, locked }) => {
-  grimoireState.grimoireLocked = !!locked;
-  applyGrimoireLockedState({ grimoireState });
-});
-
-export function toggleGrimoireLocked({ grimoireState }) {
-  setGrimoireLocked({ grimoireState, locked: !grimoireState.grimoireLocked });
 }
 
 export const setGrimoireHidden = withStateSave(({ grimoireState, hidden }) => {
@@ -83,8 +68,6 @@ function mountBluffTokensContainer({ grimoireState }) {
 export const setupGrimoire = withStateSave(({ grimoireState, grimoireHistoryList, count }) => {
   const playerCircle = document.getElementById('player-circle');
   const playerCountInput = document.getElementById('player-count');
-  grimoireState.grimoireLocked = false;
-  applyGrimoireLockedState({ grimoireState });
   try {
     if (grimoireState.gameStarted && !grimoireState.isRestoringState && Array.isArray(grimoireState.players) && grimoireState.players.length > 0) {
       snapshotCurrentGrimoire({ players: grimoireState.players, scriptMetaName: grimoireState.scriptMetaName, scriptData: grimoireState.scriptData, grimoireHistoryList, dayNightTracking: grimoireState.dayNightTracking, winner: grimoireState.winner });
@@ -193,8 +176,6 @@ export const resetGrimoire = withStateSave(({ grimoireState, grimoireHistoryList
     return createEmptyPlayer(name);
   });
   grimoireState.players = newPlayers;
-  grimoireState.grimoireLocked = false;
-  applyGrimoireLockedState({ grimoireState });
 
   rebuildPlayerCircleUiPreserveState({ grimoireState });
   grimoireState.bluffs = [null, null, null];

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -53,6 +53,39 @@ export function toggleGrimoireHidden({ grimoireState }) {
 
 export function showGrimoire({ grimoireState }) { setGrimoireHidden({ grimoireState, hidden: false }); }
 
+export function hasGrimoireSnapshot(grimoireState) {
+  return !!(grimoireState && grimoireState.tempSnapshot);
+}
+
+export const takeGrimoireSnapshot = withStateSave(({ grimoireState }) => {
+  grimoireState.tempSnapshot = {
+    players: JSON.parse(JSON.stringify(grimoireState.players || [])),
+    bluffs: JSON.parse(JSON.stringify(grimoireState.bluffs || [null, null, null])),
+    dayNightTracking: grimoireState.dayNightTracking
+      ? JSON.parse(JSON.stringify(grimoireState.dayNightTracking))
+      : null
+  };
+  try { document.body.classList.add('grimoire-snapshot-active'); } catch (_) { }
+});
+
+export const restoreGrimoireSnapshot = withStateSave(({ grimoireState }) => {
+  const snap = grimoireState.tempSnapshot;
+  if (!snap) return;
+  grimoireState.players = JSON.parse(JSON.stringify(snap.players || []));
+  grimoireState.bluffs = JSON.parse(JSON.stringify(snap.bluffs || [null, null, null]));
+  if (snap.dayNightTracking) {
+    grimoireState.dayNightTracking = JSON.parse(JSON.stringify(snap.dayNightTracking));
+  }
+  grimoireState.tempSnapshot = null;
+  try { document.body.classList.remove('grimoire-snapshot-active'); } catch (_) { }
+  rebuildPlayerCircleUiPreserveState({ grimoireState });
+  try { updateDayNightUI(grimoireState); } catch (_) { }
+});
+
+export function applyGrimoireSnapshotState({ grimoireState }) {
+  try { document.body.classList.toggle('grimoire-snapshot-active', hasGrimoireSnapshot(grimoireState)); } catch (_) { }
+}
+
 function mountBluffTokensContainer({ grimoireState }) {
   const existingContainer = document.getElementById('bluff-tokens-container');
   if (existingContainer) {
@@ -158,6 +191,8 @@ export const resetGrimoire = withStateSave(({ grimoireState, grimoireHistoryList
   try { grimoireState.grimoireHidden = false; } catch (_) { }
   try { grimoireState.winner = null; } catch (_) { }
   try { grimoireState.gameStarted = false; } catch (_) { }
+  try { grimoireState.tempSnapshot = null; } catch (_) { }
+  try { document.body.classList.remove('grimoire-snapshot-active'); } catch (_) { }
   try {
     if (!grimoireState.playerSetup) {
       grimoireState.playerSetup = { bag: [], assignments: [], revealed: false };

--- a/src/grimoire.js
+++ b/src/grimoire.js
@@ -39,6 +39,10 @@ function setupPlayerNameHandlers({ listItem, grimoireState, playerIndex }) {
 
 export function applyGrimoireHiddenState({ grimoireState }) {
   try { document.body.classList.toggle('grimoire-hidden', !!grimoireState.grimoireHidden); } catch (_) { }
+  try {
+    const banner = document.getElementById('grimoire-hidden-banner');
+    if (banner) banner.setAttribute('aria-hidden', String(!grimoireState.grimoireHidden));
+  } catch (_) { }
   updateGrimoire({ grimoireState });
 }
 

--- a/src/grimoireLock.js
+++ b/src/grimoireLock.js
@@ -1,7 +1,0 @@
-function isGrimoireLocked(grimoireState) {
-  return !!(grimoireState && grimoireState.grimoireLocked);
-}
-
-export function ensureGrimoireUnlocked({ grimoireState } = {}) {
-  return !isGrimoireLocked(grimoireState);
-}

--- a/src/playerSetup.js
+++ b/src/playerSetup.js
@@ -626,7 +626,7 @@ export function initPlayerSetup({ grimoireState }) {
       const revealBtn = document.getElementById('reveal-selected-characters');
       if (revealBtn) {
         revealBtn.style.display = sel.revealed ? 'none' : '';
-        revealBtn.disabled = !!(window.grimoireState && window.grimoireState.winner);
+        revealBtn.disabled = false;
       }
       try { if (window.updateButtonStates) window.updateButtonStates(); } catch (_) { }
       return true;
@@ -1201,7 +1201,7 @@ export function restoreSelectionSession({ grimoireState }) {
         const revealBtn = document.getElementById('reveal-selected-characters');
         if (revealBtn) {
           revealBtn.style.display = ps.revealed ? 'none' : '';
-          revealBtn.disabled = !!(grimoireState && grimoireState.winner);
+          revealBtn.disabled = false;
         }
       } catch (_) { }
       try { if (window.updateButtonStates) window.updateButtonStates(); } catch (_) { }

--- a/src/reminder.js
+++ b/src/reminder.js
@@ -27,7 +27,7 @@ export async function populateReminderTokenGrid({ grimoireState }) {
     if (!tokenEl) return;
     try { e.preventDefault(); } catch (_) { }
     try { e.stopPropagation(); } catch (_) { }
-    if (!canOpenModal({ grimoireState, requiresUnlocked: true })) return;
+    if (!canOpenModal({ grimoireState })) return;
 
     const label = tokenEl.dataset.tokenLabel || '';
 
@@ -155,7 +155,7 @@ export async function populateReminderTokenGrid({ grimoireState }) {
 
 
 export function openReminderTokenModal({ grimoireState, playerIndex }) {
-  if (!canOpenModal({ grimoireState, requiresUnlocked: true })) return;
+  if (!canOpenModal({ grimoireState })) return;
 
   const reminderTokenModal = document.getElementById('reminder-token-modal');
   const reminderTokenSearch = document.getElementById('reminder-token-search');
@@ -169,7 +169,7 @@ export function openReminderTokenModal({ grimoireState, playerIndex }) {
 }
 
 export function openTextReminderModal({ grimoireState, playerIndex, reminderIndex = -1, existingText = '' }) {
-  if (!canOpenModal({ grimoireState, requiresUnlocked: true })) return;
+  if (!canOpenModal({ grimoireState })) return;
 
   const reminderTextInput = document.getElementById('reminder-text-input');
   const textReminderModal = document.getElementById('text-reminder-modal');
@@ -180,7 +180,7 @@ export function openTextReminderModal({ grimoireState, playerIndex, reminderInde
 }
 
 export function openCustomReminderEditModal({ grimoireState, playerIndex, reminderIndex, existingText = '' }) {
-  if (!canOpenModal({ grimoireState, requiresUnlocked: true })) return;
+  if (!canOpenModal({ grimoireState })) return;
 
   const customReminderTextInput = document.getElementById('custom-reminder-text-input');
   const customReminderEditModal = document.getElementById('custom-reminder-edit-modal');

--- a/src/ui/contextMenu.js
+++ b/src/ui/contextMenu.js
@@ -2,12 +2,10 @@ import { createEmptyPlayer } from '../../utils.js';
 import { withStateSave } from '../app.js';
 import { saveCurrentPhaseState } from '../dayNightTracking.js';
 import { rebuildPlayerCircleUiPreserveState, updateGrimoire } from '../grimoire.js';
-import { ensureGrimoireUnlocked } from '../grimoireLock.js';
 import { openCustomReminderEditModal } from '../reminder.js';
 import { createContextMenu, positionContextMenu } from './menuFactory.js';
 
 export function showPlayerContextMenu({ grimoireState, x, y, playerIndex }) {
-  if (!ensureGrimoireUnlocked({ grimoireState })) return;
   const menu = ensurePlayerContextMenu({ grimoireState });
   grimoireState.contextMenuTargetIndex = playerIndex;
   grimoireState.menuOpenedAt = Date.now();
@@ -43,7 +41,6 @@ export function showPlayerContextMenu({ grimoireState, x, y, playerIndex }) {
       id: 'reminder-menu-edit',
       label: 'Edit Reminder',
       onClick: withStateSave(() => {
-        if (!ensureGrimoireUnlocked({ grimoireState })) return;
         const { playerIndex, reminderIndex } = grimoireState.reminderContextTarget;
         hideReminderContextMenu({ grimoireState });
         if (playerIndex < 0 || reminderIndex < 0) return;
@@ -82,7 +79,6 @@ export function showPlayerContextMenu({ grimoireState, x, y, playerIndex }) {
       id: 'reminder-menu-delete',
       label: 'Delete Reminder',
       onClick: withStateSave(() => {
-        if (!ensureGrimoireUnlocked({ grimoireState })) return;
         const { playerIndex, reminderIndex } = grimoireState.reminderContextTarget;
         hideReminderContextMenu({ grimoireState });
         if (playerIndex < 0 || reminderIndex < 0) return;
@@ -121,7 +117,6 @@ export function ensurePlayerContextMenu({ grimoireState }) {
   if (grimoireState.playerContextMenu) return grimoireState.playerContextMenu;
 
   const addPlayerAt = (offset) => withStateSave(() => {
-    if (!ensureGrimoireUnlocked({ grimoireState })) return;
     const idx = grimoireState.contextMenuTargetIndex;
     hidePlayerContextMenu({ grimoireState });
     if (idx < 0) return;
@@ -145,7 +140,6 @@ export function ensurePlayerContextMenu({ grimoireState }) {
       id: 'player-menu-remove',
       label: 'Remove Player',
       onClick: withStateSave(() => {
-        if (!ensureGrimoireUnlocked({ grimoireState })) return;
         const idx = grimoireState.contextMenuTargetIndex;
         hidePlayerContextMenu({ grimoireState });
         if (idx < 0) return;
@@ -165,7 +159,6 @@ export function ensurePlayerContextMenu({ grimoireState }) {
   return menu;
 }
 export function showReminderContextMenu({ grimoireState, x, y, playerIndex, reminderIndex }) {
-  if (!ensureGrimoireUnlocked({ grimoireState })) return;
   const menu = ensureReminderContextMenu({ grimoireState });
   grimoireState.reminderContextTarget = { playerIndex, reminderIndex };
   positionContextMenu(menu, x, y);

--- a/src/ui/playerCircle.js
+++ b/src/ui/playerCircle.js
@@ -29,12 +29,8 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
   const tokenEl = listItem.querySelector('.player-token');
   let touchOccurred = false;
 
-  const canInteract = () => grimoireState.mode === 'player' || !grimoireState.winner;
-
   // Click handler for player token
   tokenEl.onclick = createSafeClickHandler((e) => {
-    if (!canInteract()) return;
-
     const target = e.target;
     if (target && (target.closest('.death-ribbon') || target.classList.contains('death-ribbon'))) {
       return; // handled by ribbon click
@@ -73,7 +69,6 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
           e,
           listItem,
           actionCallback: () => {
-            if (!canInteract()) return;
             if (grimoireState && grimoireState.playerSetup && grimoireState.playerSetup.selectionActive) {
               if (window.openNumberPickerForSelection) {
                 window.openNumberPickerForSelection(playerIndex);
@@ -120,8 +115,6 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
 
   if (placeholderEl) {
     placeholderEl.onclick = createSafeClickHandler((e) => {
-      if (!canInteract()) return; // Gate adding reminders pre-game in storyteller mode
-
       const thisLi = listItem;
       if (thisLi.dataset.expanded !== '1') {
         const allLis = document.querySelectorAll('#player-circle li');

--- a/src/ui/playerCircle.js
+++ b/src/ui/playerCircle.js
@@ -6,7 +6,6 @@ import { positionRadialStack } from './layout.js';
 import { setupInteractiveElement } from '../utils/interaction.js';
 import { createSafeClickHandler } from '../utils/eventHandlers.js';
 import { handlePlayerElementTouch } from './touchHelpers.js';
-import { ensureGrimoireUnlocked } from '../grimoireLock.js';
 
 /**
  * Creates and configures a single player list item for the grimoire circle
@@ -52,7 +51,6 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
         window.openNumberPickerForSelection(playerIndex);
       }
     } else if (grimoireState && !grimoireState.grimoireHidden) {
-      if (!ensureGrimoireUnlocked({ grimoireState })) return;
       openCharacterModal({ grimoireState, playerIndex });
     }
   }, {
@@ -81,7 +79,6 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
                 window.openNumberPickerForSelection(playerIndex);
               }
             } else if (grimoireState && !grimoireState.grimoireHidden) {
-              if (!ensureGrimoireUnlocked({ grimoireState })) return;
               openCharacterModal({ grimoireState, playerIndex });
             }
           }
@@ -144,7 +141,6 @@ export function createPlayerListItem({ grimoireState, playerIndex, playerName, s
           return;
         }
       }
-      if (!ensureGrimoireUnlocked({ grimoireState })) return;
       if (isTouchDevice()) {
         openReminderTokenModal({ grimoireState, playerIndex });
       } else if (e.altKey) {

--- a/src/ui/playerUpdate.js
+++ b/src/ui/playerUpdate.js
@@ -7,7 +7,6 @@ import { showPlayerContextMenu } from './contextMenu.js';
 import { renderRemindersForPlayer, createReminderElement } from '../reminder.js';
 import { positionRadialStack } from './layout.js';
 import { showStorytellerMessage } from '../storytellerMessages.js';
-import { ensureGrimoireUnlocked } from '../grimoireLock.js';
 import { withStateSave } from '../app.js';
 
 function getAlignmentOverrideFilter({ role, player }) {
@@ -129,7 +128,6 @@ export function updatePlayerElement({
   ribbon.classList.add('death-ribbon');
   const handleRibbonToggle = withStateSave((e) => {
     e.stopPropagation();
-    if (!ensureGrimoireUnlocked({ grimoireState })) return;
     const playerSetup = grimoireState.playerSetup || {};
     const selectionActive = !!playerSetup.selectionActive;
     const selectionComplete = !!playerSetup.selectionComplete;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,12 +1,9 @@
-import { ensureGrimoireUnlocked } from '../grimoireLock.js';
-
 /**
  * Centralized validation for opening modals or performing actions.
  * Checks various prerequisites based on the provided options.
  *
  * @param {Object} params
  * @param {Object} params.grimoireState - The current application state.
- * @param {boolean} [params.requiresUnlocked=true] - If true, checks if the grimoire is unlocked.
  * @param {boolean} [params.requiresScript=false] - If true, checks if a script is loaded.
  * @param {boolean} [params.requiresNotHidden=false] - If true, checks if the grimoire is visible.
  * @param {boolean} [params.requiresStorytellerMode=false] - If true, checks if in Storyteller mode.
@@ -15,7 +12,6 @@ import { ensureGrimoireUnlocked } from '../grimoireLock.js';
  */
 export function canOpenModal({
   grimoireState,
-  requiresUnlocked = true,
   requiresScript = false,
   requiresNotHidden = false,
   requiresStorytellerMode = false,
@@ -27,20 +23,11 @@ export function canOpenModal({
     return false;
   }
 
-  if (requiresUnlocked && !ensureGrimoireUnlocked({ grimoireState })) {
-    return false;
-  }
-
   if (requiresStorytellerMode && grimoireState.mode === 'player') {
     return false;
   }
 
   if (requiresNoWinner && grimoireState.winner) {
-    // If we are in player mode, we might still want to allow interaction?
-    // The original logic in bluffTokens was: grimoireState.mode === 'player' || !grimoireState.winner
-    // So if storyteller, requires no winner.
-    // Let's handle this logic at the call site or make the flag more specific.
-    // For now, strict check.
     return false;
   }
 

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -7,15 +7,13 @@
  * @param {boolean} [params.requiresScript=false] - If true, checks if a script is loaded.
  * @param {boolean} [params.requiresNotHidden=false] - If true, checks if the grimoire is visible.
  * @param {boolean} [params.requiresStorytellerMode=false] - If true, checks if in Storyteller mode.
- * @param {boolean} [params.requiresNoWinner=false] - If true, checks if there is no winner yet.
  * @returns {boolean} True if all checks pass, false otherwise.
  */
 export function canOpenModal({
   grimoireState,
   requiresScript = false,
   requiresNotHidden = false,
-  requiresStorytellerMode = false,
-  requiresNoWinner = false
+  requiresStorytellerMode = false
 }) {
   if (!grimoireState) return false;
 
@@ -24,10 +22,6 @@ export function canOpenModal({
   }
 
   if (requiresStorytellerMode && grimoireState.mode === 'player') {
-    return false;
-  }
-
-  if (requiresNoWinner && grimoireState.winner) {
     return false;
   }
 

--- a/styles/bluff-tokens.css
+++ b/styles/bluff-tokens.css
@@ -9,6 +9,10 @@
   z-index: 10;
 }
 
+body.mode-player .bluff-tokens-container {
+  display: none;
+}
+
 /* Individual Bluff Token */
 .bluff-token {
   width: var(--bluff-token-size);

--- a/styles/core.css
+++ b/styles/core.css
@@ -334,16 +334,3 @@ body.grimoire-hidden #player-circle li .player-token > .token-role-art {
   color: #E74C3C;
   /* Light red */
 }
-body.grimoire-locked #player-circle .player-token,
-body.grimoire-locked #player-circle .player-name,
-body.grimoire-locked #player-circle .reminder-placeholder,
-body.grimoire-locked #player-circle .death-ribbon,
-body.grimoire-locked #player-circle .death-vote-indicator,
-body.grimoire-locked #bluff-tokens-container .bluff-token {
-  cursor: not-allowed;
-}
-
-body.grimoire-locked #player-circle .player-token,
-body.grimoire-locked #bluff-tokens-container .bluff-token {
-  filter: saturate(0.85);
-}

--- a/styles/core.css
+++ b/styles/core.css
@@ -226,9 +226,8 @@ body.grimoire-hidden .grimoire-hidden-banner {
   display: flex;
   position: absolute;
   inset: 0;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  padding-top: clamp(16px, 8vh, 96px);
   pointer-events: none;
   z-index: 5;
 }

--- a/styles/core.css
+++ b/styles/core.css
@@ -217,6 +217,34 @@ body.grimoire-hidden #player-circle li .player-token > .token-role-art {
   display: none !important;
 }
 
+/* Large central indicator that the grimoire is hidden */
+.grimoire-hidden-banner {
+  display: none;
+}
+
+body.grimoire-hidden .grimoire-hidden-banner {
+  display: flex;
+  position: absolute;
+  inset: 0;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: clamp(16px, 8vh, 96px);
+  pointer-events: none;
+  z-index: 5;
+}
+
+body.grimoire-hidden .grimoire-hidden-banner span {
+  font-size: clamp(28px, 6vmin, 64px);
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  color: #ffd166;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.55);
+  padding: 12px 24px;
+  border-radius: var(--radius-md);
+  border: 2px solid rgba(255, 255, 255, 0.18);
+}
+
 /* Remove pre-game overlay; keep day/night toggle interactive at all times */
 #day-night-toggle { pointer-events: auto; opacity: 1; cursor: pointer; }
 

--- a/styles/day-night-tracking.css
+++ b/styles/day-night-tracking.css
@@ -120,6 +120,67 @@ body.character-panel-open .export-print-toggle {
   right: calc(86px + clamp(300px, 30vw, 560px));
 }
 
+/* Grimoire snapshot/restore toggle (storyteller only) */
+.grimoire-snapshot-toggle {
+  position: fixed;
+  bottom: var(--space-5);
+  right: 218px;
+  width: var(--touch-target-xl);
+  height: var(--touch-target-xl);
+  padding: 0;
+  z-index: 1683;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  box-shadow: var(--shadow-xl);
+  transition: all var(--transition-base);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.grimoire-snapshot-toggle:hover {
+  transform: scale(1.08);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.6);
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .grimoire-snapshot-toggle:active {
+    transform: scale(0.95);
+    transition: transform 0.1s ease;
+  }
+}
+
+.grimoire-snapshot-toggle.active {
+  background: linear-gradient(135deg, #d97706 0%, #f59e0b 100%);
+  color: #1a1a1a;
+  border-color: #f59e0b;
+}
+
+body.character-panel-open .grimoire-snapshot-toggle {
+  right: calc(218px + clamp(300px, 30vw, 560px));
+}
+
+/* Banner shown when temp snapshot is active */
+body.grimoire-snapshot-active::after {
+  content: 'TEMPORARY CHANGES — original grimoire saved';
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 14px;
+  border-radius: var(--radius-md);
+  background: rgba(217, 119, 6, 0.92);
+  color: #1a1a1a;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+  z-index: 2000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
 .display-settings-panel {
   position: fixed;
   bottom: 85px;

--- a/tests/25_current_game_export_import.cy.js
+++ b/tests/25_current_game_export_import.cy.js
@@ -72,7 +72,6 @@ describe('Current Game Export/Import', () => {
         bluffs: [null, null, null],
         mode: 'storyteller',
         grimoireHidden: false,
-        grimoireLocked: false,
         playerSetup: { bag: [], assignments: [], revealed: false },
         gameStarted: true,
         winner: null

--- a/tests/28_player_setup_bag.cy.js
+++ b/tests/28_player_setup_bag.cy.js
@@ -186,10 +186,9 @@ describe('Player Setup - Bag Flow (Storyteller mode)', () => {
     cy.fillBag();
     cy.get('#bag-count-warning').should('not.be.visible');
 
-    // Start selection should NOT lock or hide grimoire; button remains "Lock Grimoire"
+    // Start selection should NOT hide grimoire
     cy.get('#player-setup-panel .start-selection').click();
     cy.get('body').should('not.have.class', 'grimoire-hidden');
-    cy.get('#grimoire-lock-toggle').should('contain', 'Lock Grimoire');
     // Selection prompt opens immediately for the first player
     cy.get('#number-picker-overlay').should('be.visible');
   });

--- a/tests/29_grimoire_hide_toggle.cy.js
+++ b/tests/29_grimoire_hide_toggle.cy.js
@@ -16,17 +16,17 @@ describe('Grimoire visibility controls', () => {
     cy.get('#reveal-assignments').should('not.be.visible');
   });
 
-  it('hides and shows tokens, reminders, and bluffs while keeping blank circles in player mode', () => {
+  it('hides and shows tokens and reminders while keeping blank circles in player mode', () => {
     // Switch to player mode to expose hide/show button
     cy.get('#mode-player').click({ force: true });
     cy.startGame();
     cy.get('#sidebar-backdrop').click({ force: true });
     cy.get('#reveal-assignments').should('contain', 'Hide Grimoire');
 
-    // Verify baseline visible elements
+    // Verify baseline visible elements (bluffs are storyteller-only and hidden here)
     cy.get('#player-circle li .player-token').should('have.length', 5);
     cy.get('#player-circle li .reminder-placeholder').should('be.visible');
-    cy.get('#bluff-tokens-container').should('be.visible');
+    cy.get('#bluff-tokens-container').should('not.be.visible');
 
     // Hide grimoire
     cy.get('#reveal-assignments').click({ force: true });
@@ -34,7 +34,7 @@ describe('Grimoire visibility controls', () => {
     // Reminders and plus should be hidden
     cy.get('#player-circle li .reminders').should('not.be.visible');
     cy.get('#player-circle li .reminder-placeholder').should('not.be.visible');
-    // Bluff tokens hidden
+    // Bluff tokens still hidden (player mode)
     cy.get('#bluff-tokens-container').should('not.be.visible');
 
     // Player token still visible, but only base background (no character overlay)
@@ -45,9 +45,19 @@ describe('Grimoire visibility controls', () => {
         expect(style.backgroundImage).to.contain('token.png');
       });
 
-    // Show grimoire again
+    // Show grimoire again — bluffs remain hidden in player mode
     cy.get('#reveal-assignments').click({ force: true });
     cy.get('#player-circle li .reminder-placeholder').should('be.visible');
+    cy.get('#bluff-tokens-container').should('not.be.visible');
+  });
+
+  it('hides bluff tokens entirely in player mode and shows them in storyteller mode', () => {
+    cy.get('#bluff-tokens-container').should('be.visible');
+
+    cy.get('#mode-player').click({ force: true });
+    cy.get('#bluff-tokens-container').should('not.be.visible');
+
+    cy.get('#mode-storyteller').click({ force: true });
     cy.get('#bluff-tokens-container').should('be.visible');
   });
 

--- a/tests/29_grimoire_hide_toggle.cy.js
+++ b/tests/29_grimoire_hide_toggle.cy.js
@@ -1,4 +1,4 @@
-describe('Grimoire visibility & locking controls', () => {
+describe('Grimoire visibility controls', () => {
   beforeEach(() => {
     cy.visit('/');
     cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) { } });
@@ -6,16 +6,13 @@ describe('Grimoire visibility & locking controls', () => {
     cy.setupGame({ players: 5, loadScript: false });
   });
 
-  it('shows hide/show control only in player mode and lock control only in storyteller mode', () => {
-    cy.get('#grimoire-lock-toggle').should('be.visible').and('contain', 'Lock Grimoire');
+  it('shows hide/show control only in player mode', () => {
     cy.get('#reveal-assignments').should('not.be.visible');
 
     cy.get('#mode-player').click({ force: true });
-    cy.get('#grimoire-lock-toggle').should('not.be.visible');
     cy.get('#reveal-assignments').should('be.visible').and('contain', 'Hide Grimoire');
 
     cy.get('#mode-storyteller').click({ force: true });
-    cy.get('#grimoire-lock-toggle').should('be.visible').and('contain', 'Lock Grimoire');
     cy.get('#reveal-assignments').should('not.be.visible');
   });
 
@@ -91,32 +88,10 @@ describe('Grimoire visibility & locking controls', () => {
     cy.get('#reveal-assignments').click();
   });
 
-  it('locks grimoire actions in storyteller mode until unlocked', () => {
-    // Add a reminder to attempt to delete later
-    cy.get('#player-circle li .reminder-placeholder').first().click({ altKey: true, force: true });
-    cy.get('#text-reminder-modal').should('be.visible');
-    cy.get('#reminder-text-input').type('Locked reminder');
-    cy.get('#save-reminder-btn').click({ force: true });
-    cy.get('#text-reminder-modal').should('not.be.visible');
-    cy.get('#player-circle li').first().find('.text-reminder').should('have.length', 1);
-
-    // Lock the grimoire
-    cy.get('#grimoire-lock-toggle').should('contain', 'Lock Grimoire').click();
-    cy.get('#grimoire-lock-toggle').should('contain', 'Unlock Grimoire');
-    cy.get('body').should('have.class', 'grimoire-locked');
-
-    // Attempting to delete reminders should be blocked
-    cy.get('#player-circle li').first().find('.text-reminder').first().trigger('contextmenu', { force: true });
-    cy.get('body').find('#reminder-context-menu').should('have.length', 0);
-    cy.get('#player-circle li').first().find('.text-reminder').should('have.length', 1);
-
-    // Unlock and verify deletion works again
-    cy.get('#grimoire-lock-toggle').click();
-    cy.get('#grimoire-lock-toggle').should('contain', 'Lock Grimoire');
+  it('does not expose any grimoire lock toggle anywhere', () => {
+    cy.get('#grimoire-lock-toggle').should('not.exist');
+    cy.get('#mode-player').click({ force: true });
+    cy.get('#grimoire-lock-toggle').should('not.exist');
     cy.get('body').should('not.have.class', 'grimoire-locked');
-    cy.get('#player-circle li').first().find('.text-reminder').first().trigger('contextmenu', { force: true });
-    cy.get('#reminder-context-menu').should('be.visible');
-    cy.get('#reminder-menu-delete').click({ force: true });
-    cy.get('#player-circle li').first().find('.text-reminder').should('have.length', 0);
   });
 });

--- a/tests/30_player_setup_flow_guards.cy.js
+++ b/tests/30_player_setup_flow_guards.cy.js
@@ -128,9 +128,10 @@ describe('Player Setup - Guards and Resets', () => {
     cy.get('#end-game').click();
     cy.get('#end-game-modal').should('be.visible');
     cy.get('#good-wins-btn').click();
-    // After winner, Open Player Setup should be disabled until reset
+    // After full setup completed, open-player-setup is gated by selectionComplete
+    // until a reset, regardless of winner state
     cy.get('#open-player-setup').should('be.disabled');
-    // Reset grimoire (no confirmation expected because gameStarted is false and winner set)
+    // Reset grimoire (no confirmation expected because winner is set, gameStarted is false)
     cy.get('#reset-grimoire').click();
     cy.get('#open-player-setup').should('not.be.disabled').click();
     // Re-fill bag and start selection again after reset to regenerate overlays

--- a/tests/36_reset_grimoire_meta.cy.js
+++ b/tests/36_reset_grimoire_meta.cy.js
@@ -1,5 +1,5 @@
 describe('Reset Grimoire meta state', () => {
-  it('clears winner, unlocks grimoire, and empties player setup bag', () => {
+  it('clears winner and empties player setup bag', () => {
     cy.visit('/');
     cy.ensureStorytellerMode();
 
@@ -22,11 +22,6 @@ describe('Reset Grimoire meta state', () => {
     });
     cy.get('#player-setup-panel .close-button, #close-player-setup').click({ multiple: true, force: true });
 
-    // Lock the grimoire to ensure reset clears the state
-    cy.get('#grimoire-lock-toggle').should('contain', 'Lock Grimoire').click();
-    cy.get('#grimoire-lock-toggle').should('contain', 'Unlock Grimoire');
-    cy.get('body').should('have.class', 'grimoire-locked');
-
     // Declare winner via button
     cy.get('#good-wins-btn').click({ force: true });
     cy.get('#winner-message').should('contain.text', 'Good has won');
@@ -36,10 +31,6 @@ describe('Reset Grimoire meta state', () => {
 
     // Winner cleared
     cy.get('#winner-message').should('not.exist');
-
-    // Grimoire unlocked
-    cy.get('body').should('not.have.class', 'grimoire-locked');
-    cy.get('#grimoire-lock-toggle').should('contain', 'Lock Grimoire');
 
     // Player setup bag emptied: open panel and expect zero checked checkboxes
     cy.get('#open-player-setup').click();

--- a/tests/38_winner_gating.cy.js
+++ b/tests/38_winner_gating.cy.js
@@ -1,14 +1,14 @@
 /// <reference types="cypress" />
 
-// Test: After declaring a winner (ending the game), Start Game and Player Setup are disabled until reset.
+// Test: After declaring a winner the storyteller can still edit and reset; no gating.
 
-describe('Winner gating disables start flow until reset', () => {
+describe('Winner does not gate post-game editing or setup', () => {
   beforeEach(() => {
     cy.resetApp({ mode: 'storyteller', loadScript: false });
   });
 
 
-  it('gates start/player setup after winner until reset', () => {
+  it('keeps player setup and end-game-related controls usable after a winner is declared', () => {
     cy.ensureSidebarOpen();
 
     // Controls should be available immediately since players are preloaded
@@ -28,10 +28,11 @@ describe('Winner gating disables start flow until reset', () => {
     cy.get('#end-game-modal').should('be.visible');
     cy.get('#good-wins-btn').click();
 
-    // Gate should apply
-    cy.get('#open-player-setup').should('be.disabled');
+    // Open Player Setup remains usable; End Game button is hidden because the game is over
+    cy.get('#open-player-setup').should('not.be.disabled');
+    cy.get('#end-game').should('not.be.visible');
 
-    // Reset to clear gate
+    // Reset still works
     cy.on('window:confirm', () => true);
     cy.get('#reset-grimoire').click({ force: true });
 

--- a/tests/51_post_game_editing.cy.js
+++ b/tests/51_post_game_editing.cy.js
@@ -1,0 +1,56 @@
+describe('Post-game grimoire editing', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) { } });
+    cy.ensureStorytellerMode();
+    cy.setupGame({ players: 5, loadScript: true, mode: 'storyteller' });
+  });
+
+  it('lets the storyteller edit characters, reminders and deaths after a winner is declared, and persists across reloads', () => {
+    // Assign a starter character so a game is in progress
+    cy.get('#player-circle li').eq(0).find('.player-token').click({ force: true });
+    cy.get('#character-modal').should('be.visible');
+    cy.get('#character-grid .token[title="Chef"]').first().click({ force: true });
+    cy.get('#character-modal').should('not.be.visible');
+
+    // Declare winner
+    cy.get('#end-game').click({ force: true });
+    cy.get('#good-wins-btn').click({ force: true });
+    cy.get('#winner-message').should('contain.text', 'Good has won');
+
+    // Open Player Setup should NOT be disabled by the winner
+    cy.get('#open-player-setup').should('not.be.disabled');
+
+    // Reassign a character on player 1 (post-winner)
+    cy.get('#player-circle li').eq(1).find('.player-token').click({ force: true });
+    cy.get('#character-modal').should('be.visible');
+    cy.get('#character-grid .token[title="Imp"]').first().click({ force: true });
+    cy.get('#character-modal').should('not.be.visible');
+    cy.get('#player-circle li').eq(1).find('.character-name').should('contain', 'Imp');
+
+    // Add a reminder to player 2 (post-winner) via alt-click on placeholder
+    cy.get('#player-circle li').eq(2).find('.reminder-placeholder').click({ altKey: true, force: true });
+    cy.get('#text-reminder-modal').should('be.visible');
+    cy.get('#reminder-text-input').type('post-winner reminder');
+    cy.get('#save-reminder-btn').click({ force: true });
+    cy.get('#text-reminder-modal').should('not.be.visible');
+    cy.get('#player-circle li').eq(2).find('.text-reminder').should('have.length', 1);
+
+    // Toggle the death ribbon on player 0 (post-winner)
+    cy.get('#player-circle li').eq(0).find('.death-ribbon').click({ force: true });
+    cy.get('#player-circle li').eq(0).find('.player-token').should('have.class', 'is-dead');
+
+    // Assign a bluff token (post-winner) — pick Empath (not in play)
+    cy.get('#bluff-tokens-container .bluff-token').first().click({ force: true });
+    cy.get('#character-modal').should('be.visible');
+    cy.get('#character-grid .token[title="Empath"]').first().click({ force: true });
+    cy.get('#character-modal').should('not.be.visible');
+
+    // Reload — edits must persist
+    cy.reload();
+    cy.get('#player-circle li').eq(1).find('.character-name').should('contain', 'Imp');
+    cy.get('#player-circle li').eq(2).find('.text-reminder').should('have.length', 1);
+    cy.get('#player-circle li').eq(0).find('.player-token').should('have.class', 'is-dead');
+    cy.get('#bluff-tokens-container .bluff-token').first().should('have.attr', 'data-character', 'empath');
+  });
+});

--- a/tests/52_temporary_grimoire_snapshot.cy.js
+++ b/tests/52_temporary_grimoire_snapshot.cy.js
@@ -14,6 +14,50 @@ describe('Temporary grimoire snapshot/restore', () => {
     cy.get('#grimoire-snapshot-toggle').should('be.visible');
   });
 
+  it('clears any active snapshot when importing a game without one', () => {
+    // Take a snapshot so tempSnapshot is non-null in memory + localStorage
+    cy.get('#grimoire-snapshot-toggle').click({ force: true });
+    cy.get('#grimoire-snapshot-toggle').should('have.attr', 'aria-pressed', 'true');
+    cy.get('body').should('have.class', 'grimoire-snapshot-active');
+
+    // Import a fresh game whose payload explicitly has tempSnapshot: null
+    const importData = {
+      version: 1,
+      exportDate: new Date().toISOString(),
+      gameState: {
+        scriptData: [{ id: '_meta', name: 'Imported Script', author: 'cypress' }, 'butler'],
+        scriptMetaName: 'Imported Script',
+        includeTravellers: false,
+        players: [
+          { name: 'Alice', character: 'butler', reminders: [], dead: false, deathVote: false, nightKilledPhase: null },
+          { name: 'Bob', character: null, reminders: [], dead: false, deathVote: false, nightKilledPhase: null },
+          { name: 'Cara', character: null, reminders: [], dead: false, deathVote: false, nightKilledPhase: null },
+          { name: 'Dan', character: null, reminders: [], dead: false, deathVote: false, nightKilledPhase: null },
+          { name: 'Eve', character: null, reminders: [], dead: false, deathVote: false, nightKilledPhase: null }
+        ],
+        dayNightTracking: { enabled: false, phases: ['N1'], currentPhaseIndex: 0, reminderTimestamps: {} },
+        bluffs: [null, null, null],
+        mode: 'storyteller',
+        grimoireHidden: false,
+        playerSetup: { bag: [], assignments: [], revealed: false },
+        gameStarted: true,
+        winner: null,
+        tempSnapshot: null
+      }
+    };
+    cy.get('#import-data-file').selectFile({
+      contents: Cypress.Buffer.from(JSON.stringify(importData)),
+      fileName: 'botc-game.json',
+      mimeType: 'application/json'
+    }, { force: true });
+    cy.get('#import-status').should('contain', 'Game imported successfully');
+
+    // The previously-active snapshot must not leak into the newly imported game
+    cy.get('body').should('not.have.class', 'grimoire-snapshot-active');
+    cy.get('#grimoire-snapshot-toggle').should('have.attr', 'aria-pressed', 'false');
+    cy.window().its('grimoireState.tempSnapshot').should('be.null');
+  });
+
   it('snapshots state on click and restores it on second click, persisting across reloads', () => {
     // Establish baseline: assign Chef to player 0, add a reminder to player 1
     cy.get('#player-circle li').eq(0).find('.player-token').click({ force: true });

--- a/tests/52_temporary_grimoire_snapshot.cy.js
+++ b/tests/52_temporary_grimoire_snapshot.cy.js
@@ -1,0 +1,67 @@
+describe('Temporary grimoire snapshot/restore', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) { } });
+    cy.ensureStorytellerMode();
+    cy.setupGame({ players: 5, loadScript: true, mode: 'storyteller' });
+  });
+
+  it('shows the snapshot toggle only in storyteller mode', () => {
+    cy.get('#grimoire-snapshot-toggle').should('be.visible');
+    cy.get('#mode-player').click({ force: true });
+    cy.get('#grimoire-snapshot-toggle').should('not.be.visible');
+    cy.get('#mode-storyteller').click({ force: true });
+    cy.get('#grimoire-snapshot-toggle').should('be.visible');
+  });
+
+  it('snapshots state on click and restores it on second click, persisting across reloads', () => {
+    // Establish baseline: assign Chef to player 0, add a reminder to player 1
+    cy.get('#player-circle li').eq(0).find('.player-token').click({ force: true });
+    cy.get('#character-modal').should('be.visible');
+    cy.get('#character-grid .token[title="Chef"]').first().click({ force: true });
+    cy.get('#character-modal').should('not.be.visible');
+    cy.get('#player-circle li').eq(0).find('.character-name').should('contain', 'Chef');
+
+    cy.get('#player-circle li').eq(1).find('.reminder-placeholder').click({ altKey: true, force: true });
+    cy.get('#text-reminder-modal').should('be.visible');
+    cy.get('#reminder-text-input').type('original reminder');
+    cy.get('#save-reminder-btn').click({ force: true });
+    cy.get('#text-reminder-modal').should('not.be.visible');
+    cy.get('#player-circle li').eq(1).find('.text-reminder').should('have.length', 1);
+
+    // Take snapshot
+    cy.get('#grimoire-snapshot-toggle')
+      .should('have.attr', 'aria-pressed', 'false')
+      .click({ force: true });
+    cy.get('#grimoire-snapshot-toggle').should('have.attr', 'aria-pressed', 'true');
+    cy.get('#grimoire-snapshot-toggle').invoke('attr', 'title').should('match', /Restore/i);
+    cy.get('body').should('have.class', 'grimoire-snapshot-active');
+
+    // Make temporary changes: reassign player 0 to Imp, delete reminder on player 1
+    cy.get('#player-circle li').eq(0).find('.player-token').click({ force: true });
+    cy.get('#character-modal').should('be.visible');
+    cy.get('#character-grid .token[title="Imp"]').first().click({ force: true });
+    cy.get('#character-modal').should('not.be.visible');
+    cy.get('#player-circle li').eq(0).find('.character-name').should('contain', 'Imp');
+
+    cy.get('#player-circle li').eq(1).find('.text-reminder').first().trigger('contextmenu', { force: true });
+    cy.get('#reminder-context-menu').should('be.visible');
+    cy.get('#reminder-menu-delete').click({ force: true });
+    cy.get('#player-circle li').eq(1).find('.text-reminder').should('have.length', 0);
+
+    // Reload — temporary state and toggle state must persist
+    cy.reload();
+    cy.get('#player-circle li').eq(0).find('.character-name').should('contain', 'Imp');
+    cy.get('#player-circle li').eq(1).find('.text-reminder').should('have.length', 0);
+    cy.get('#grimoire-snapshot-toggle').should('have.attr', 'aria-pressed', 'true');
+    cy.get('body').should('have.class', 'grimoire-snapshot-active');
+
+    // Restore
+    cy.get('#grimoire-snapshot-toggle').click({ force: true });
+    cy.get('#grimoire-snapshot-toggle').should('have.attr', 'aria-pressed', 'false');
+    cy.get('#grimoire-snapshot-toggle').invoke('attr', 'title').should('match', /Make temporary/i);
+    cy.get('body').should('not.have.class', 'grimoire-snapshot-active');
+    cy.get('#player-circle li').eq(0).find('.character-name').should('contain', 'Chef');
+    cy.get('#player-circle li').eq(1).find('.text-reminder').should('have.length', 1);
+  });
+});

--- a/tests/53_grimoire_hidden_indicator.cy.js
+++ b/tests/53_grimoire_hidden_indicator.cy.js
@@ -1,0 +1,31 @@
+describe('Grimoire hidden indicator overlay', () => {
+  beforeEach(() => {
+    cy.visit('/');
+    cy.window().then((win) => { try { win.localStorage.clear(); } catch (_) { } });
+    cy.ensureStorytellerMode();
+    cy.setupGame({ players: 5, loadScript: false });
+  });
+
+  it('shows a large central GRIMOIRE HIDDEN banner only when the grimoire is hidden', () => {
+    cy.get('#mode-player').click({ force: true });
+    cy.startGame();
+    cy.get('#sidebar-backdrop').click({ force: true });
+
+    // Default: not hidden, banner not shown
+    cy.get('#grimoire-hidden-banner').should('not.be.visible');
+    cy.get('#grimoire-hidden-banner').should('have.attr', 'aria-hidden', 'true');
+
+    // Hide grimoire
+    cy.get('#reveal-assignments').click({ force: true });
+    cy.get('body').should('have.class', 'grimoire-hidden');
+    cy.get('#grimoire-hidden-banner').should('be.visible');
+    cy.get('#grimoire-hidden-banner').should('contain.text', 'GRIMOIRE HIDDEN');
+    cy.get('#grimoire-hidden-banner').should('have.attr', 'aria-hidden', 'false');
+
+    // Show grimoire again
+    cy.get('#reveal-assignments').click({ force: true });
+    cy.get('body').should('not.have.class', 'grimoire-hidden');
+    cy.get('#grimoire-hidden-banner').should('not.be.visible');
+    cy.get('#grimoire-hidden-banner').should('have.attr', 'aria-hidden', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- **Removes the Lock Grimoire button and all gating logic.** No more `grimoireLocked` state, `ensureGrimoireUnlocked` checks, or `body.grimoire-locked` styles. Storyteller can always edit the grimoire.
- **Allows editing the grimoire after the game has finished.** `canInteract`'s winner check, `requiresNoWinner` validation, and the post-winner disabled buttons (`open-player-setup`, `reveal-selected-characters`) are all removed. Edits flow through the existing `withStateSave` → localStorage save path so they persist across reloads.
- **Adds a "Make temporary changes" toggle (`#grimoire-snapshot-toggle`)** in the night-mode controls cluster (storyteller-only). Click once to snapshot players + bluffs + day/night tracking; click again to restore. Snapshot persists across reloads via localStorage. While active, an amber banner ("TEMPORARY CHANGES — original grimoire saved") shows at the top of the grimoire.
- **Adds a large central "GRIMOIRE HIDDEN" overlay** when the grimoire is hidden, so the operator can't miss it.

## Test plan
- [x] `./test-parallel.sh` passes after every commit
- [x] No `Lock Grimoire` / `Unlock Grimoire` button anywhere; existing tests updated to assert it does not exist (`tests/29_grimoire_hide_toggle.cy.js`).
- [x] Storyteller can edit characters / reminders / bluffs / death after a winner is declared, and edits survive reload (`tests/51_post_game_editing.cy.js`).
- [x] Make temporary changes → modify → reload → Restore → original state returns (`tests/52_temporary_grimoire_snapshot.cy.js`).
- [x] Hide Grimoire shows a prominent center overlay; Show Grimoire hides it (`tests/53_grimoire_hidden_indicator.cy.js`).
- [x] Visual screenshots captured via Playwright for: lock removal, snapshot toggle (default + active), hidden overlay.

## Commits
1. `chore: open PR for grimoire snapshot/restore feature` — empty seed commit so the PR could be opened first.
2. `refactor: remove grimoire lock button and gating logic`
3. `feat: allow editing the grimoire after the game has finished`
4. `feat: add temporary grimoire snapshot/restore toggle`
5. `feat: show large overlay when grimoire is hidden`
